### PR TITLE
feat: Implement Body and Create Instruction Struct

### DIFF
--- a/achiever/Cargo.toml
+++ b/achiever/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 authors.workspace = true
 
 [dependencies]
+slotmap = "1.0.7"
 
 [lib]
 

--- a/achiever/src/body.rs
+++ b/achiever/src/body.rs
@@ -11,9 +11,22 @@ pub mod outputs;
 /// how we want to do this. My main idea is we can have an enum for Input/Output, and from there
 /// some sort of method for reading or writing. The a body would only be a Vec<Peripheral> but we
 /// could maybe also do a graph like structure
+#[derive(Default)]
 pub struct Body {
     /// The dependency graph of all Peripherals
     pub peripheral_graph: SlotMap<PeripheralKey, PeripheralNode>,
+}
+
+impl Body {
+    /// Returns all input nodes
+    pub fn inputs(&self) -> Vec<&PeripheralNode> {
+        self.peripheral_graph.iter().filter(|(_, node)| node.peripheral.is_input()).map(|(_, node)| node).collect::<Vec<_>>()
+    }
+
+    /// Returns all output nodes
+    pub fn outputs(&self) -> Vec<&PeripheralNode> {
+        self.peripheral_graph.iter().filter(|(_, node)| node.peripheral.is_output()).map(|(_, node)| node).collect::<Vec<_>>()
+    }
 }
 
 /// An arbitrary peripheral that is either an input or output
@@ -22,6 +35,18 @@ pub enum Peripheral {
     Input(Box<dyn Input>),
     /// Output peripheral
     Output(Box<dyn Output>),
+}
+
+impl Peripheral {
+    /// Returns true if the peripheral is an input
+    pub fn is_input(&self) -> bool {
+        matches!(self, Self::Input(_))
+    }
+
+    /// Returns true if the peripheral is an output
+    pub fn is_output(&self) -> bool {
+        matches!(self, Self::Output(_))
+    }
 }
 
 /// A node in a hardware graph that describes what peripheral it is and what it's connected in some

--- a/achiever/src/body.rs
+++ b/achiever/src/body.rs
@@ -1,8 +1,39 @@
 //! The hardware controls for the agent
 
+use inputs::Input;
+use outputs::Output;
+use slotmap::{new_key_type, SlotMap};
+
+pub mod inputs;
+pub mod outputs;
+
 /// Abstraction over the hardware of the device. This is still TODO because I don't exactly know
 /// how we want to do this. My main idea is we can have an enum for Input/Output, and from there
 /// some sort of method for reading or writing. The a body would only be a Vec<Peripheral> but we
 /// could maybe also do a graph like structure
-#[derive(Debug, PartialEq, PartialOrd)]
-pub struct Body;
+pub struct Body {
+    /// The dependency graph of all Peripherals
+    pub peripheral_graph: SlotMap<PeripheralKey, PeripheralNode>,
+}
+
+/// An arbitrary peripheral that is either an input or output
+pub enum Peripheral {
+    /// Input peripheral
+    Input(Box<dyn Input>),
+    /// Output peripheral
+    Output(Box<dyn Output>),
+}
+
+/// A node in a hardware graph that describes what peripheral it is and what it's connected in some
+/// way to
+pub struct PeripheralNode {
+    /// The peripheral at this node
+    pub peripheral: Peripheral,
+    /// All peripherals this peripheral connects to
+    pub points_to: Option<Vec<PeripheralKey>>,
+}
+
+new_key_type! {
+    /// The peripheral's ID
+    pub struct PeripheralKey;
+}

--- a/achiever/src/body.rs
+++ b/achiever/src/body.rs
@@ -38,6 +38,16 @@ impl Body {
             .map(|(_, node)| node)
             .collect::<Vec<_>>()
     }
+
+    /// Gets a peripheral by its ID if it exists
+    pub fn get_by_id(&self, id: PeripheralKey) -> Option<&PeripheralNode> {
+        self.peripheral_graph.get(id)
+    }
+
+    /// Gets a mutable reference to a peripheral by its ID if it exists
+    pub fn get_by_id_mut(&mut self, id: PeripheralKey) -> Option<&mut PeripheralNode> {
+        self.peripheral_graph.get_mut(id)
+    }
 }
 
 /// An arbitrary peripheral that is either an input or output

--- a/achiever/src/body.rs
+++ b/achiever/src/body.rs
@@ -79,10 +79,10 @@ pub struct PeripheralNode {
     pub points_to: Option<Vec<PeripheralKey>>,
 }
 
-impl Into<PeripheralNode> for Peripheral {
-    fn into(self) -> PeripheralNode {
+impl From<Peripheral> for PeripheralNode {
+    fn from(value: Peripheral) -> Self {
         PeripheralNode {
-            peripheral: self,
+            peripheral: value,
             points_to: None,
         }
     }
@@ -95,7 +95,9 @@ new_key_type! {
 
 /// Builder for a Body
 pub struct Builder {
+    /// The root peripheral and all peripherals with no parents
     root: Vec<PeripheralKey>,
+    /// All peripherals
     graph: SlotMap<PeripheralKey, PeripheralNode>,
 }
 

--- a/achiever/src/body/inputs.rs
+++ b/achiever/src/body/inputs.rs
@@ -1,0 +1,7 @@
+//! Trait defining a peripheral input
+
+/// A trait for inputs, defines a single method for polling the peripheral's data
+pub trait Input {
+    /// Read bytes from peripheral to output
+    fn read(&mut self) -> Vec<u8>;
+}

--- a/achiever/src/body/outputs.rs
+++ b/achiever/src/body/outputs.rs
@@ -1,0 +1,7 @@
+//! Trait defining a peripheral output
+
+/// A trait for outputs, defines a single method for writing bytes to an output
+pub trait Output {
+    /// Write bytes to an output peripheral
+    fn write(&mut self, bytes: &[u8]);
+}

--- a/achiever/src/brain.rs
+++ b/achiever/src/brain.rs
@@ -2,5 +2,6 @@
 
 pub mod agent;
 pub mod buffer;
+pub mod instruction;
 
 pub use agent::AgentSession;

--- a/achiever/src/brain/agent.rs
+++ b/achiever/src/brain/agent.rs
@@ -117,23 +117,3 @@ impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize> Builder<'agent, REWAR
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::{body::Body, goals::Goal};
-
-    use super::{AgentSession, Untrained};
-
-    #[test]
-    fn agent_session_builder() {
-        let body = Body;
-        let agent = AgentSession::<'_, f32, Untrained, 10>::builder()
-            .with_goal(Goal::None)
-            .with_body(&body)
-            .build()
-            .expect("Build a completed agent");
-
-        assert_eq!(agent.get_body(), &body);
-        assert_eq!(agent.get_reward(), None);
-    }
-}

--- a/achiever/src/brain/instruction.rs
+++ b/achiever/src/brain/instruction.rs
@@ -1,0 +1,27 @@
+//! Movement instructions for an Agent's Body
+
+use crate::body::PeripheralKey;
+
+/// A single instruction of movement for an Agent
+pub struct Instruction {
+    /// The node affected by the instruction
+    pub node: PeripheralKey,
+    /// The timespan this action lasts for
+    pub lasts_for_ms: f32,
+    /// The arbitrary data to send to the agent
+    pub instructions: [u8; 4],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Instruction;
+
+    #[test]
+    fn instruction_has_no_padding() {
+        let size = std::mem::size_of::<Instruction>();
+        let align = std::mem::align_of::<Instruction>();
+
+        assert_eq!(size, 16);
+        assert_eq!(align, 4);
+    }
+}

--- a/achiever/src/brain/instruction.rs
+++ b/achiever/src/brain/instruction.rs
@@ -7,7 +7,7 @@ pub struct Instruction {
     /// The node affected by the instruction
     pub node: PeripheralKey,
     /// The timespan this action lasts for
-    pub lasts_for_ms: f32,
+    pub lasts_for_ms: u32,
     /// The arbitrary data to send to the agent
     pub instructions: [u8; 4],
 }


### PR DESCRIPTION
* :sparkles: Flesh out Body struct to contain a `SlotMap` of `PeripheralNode`s. 
    - This allows us to build up context for a body with peripherals that depend on one another
* :sparkles: Create `Output` and `Input` trait for reading or writing to a generic peripheral. Once we have the Jetson stuff implemented we can then implement these traits for Servo motors and Sensors 
* :sparkles: Create `Instruction` struct, a 16 byte instruction containing a Peripheral ID, the delay time this instruction should take, and 4 bytes of data to send to the output
* :white_check_mark: Create test to ensure there is no padding generated in the Instruction and that it has a size of 16 bytes and an alignment of 4 bytes
* :sparkles: Add instruction evaluation function to a trained Agent :)