### PR TITLE
Input and Output implementations for Raspberry Pi

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
         run: rustup update stable && rustup default stable
       - name: Install clippy
         run: rustup component add clippy
-      - run: cargo clippy --all-features -- --deny warnings
+      - run: cargo clippy -- --deny warnings
 
   test:
     runs-on: ubuntu-22.04
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - run: cargo test --all-features
+      - run: cargo test
 
   test-examples:
     runs-on: ubuntu-22.04
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - run: cargo test --all-features --examples
+      - run: cargo test --examples
 
   docs:
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 authors = ["BradenEverson"]
+

--- a/achiever/Cargo.toml
+++ b/achiever/Cargo.toml
@@ -5,9 +5,15 @@ version.workspace = true
 authors.workspace = true
 
 [dependencies]
+rppal = { version = "0.19.0", optional = true }
 slotmap = "1.0.7"
 
 [lib]
+
+[features]
+default = ["rpi"]
+rpi = ["dep:rppal"]
+jetson = []
 
 [lints.rust]
 missing_docs = "warn"

--- a/achiever/src/body.rs
+++ b/achiever/src/body.rs
@@ -57,7 +57,7 @@ pub enum Peripheral {
     /// Input peripheral
     Input(Box<dyn Input<Error = Box<dyn Error>>>),
     /// Output peripheral
-    Output(Box<dyn Output>),
+    Output(Box<dyn Output<Error = Box<dyn Error>>>),
 }
 
 impl Peripheral {

--- a/achiever/src/body.rs
+++ b/achiever/src/body.rs
@@ -1,5 +1,7 @@
 //! The hardware controls for the agent
 
+use std::error::Error;
+
 use inputs::Input;
 use outputs::Output;
 use slotmap::{new_key_type, SlotMap};
@@ -53,7 +55,7 @@ impl Body {
 /// An arbitrary peripheral that is either an input or output
 pub enum Peripheral {
     /// Input peripheral
-    Input(Box<dyn Input>),
+    Input(Box<dyn Input<Error = Box<dyn Error>>>),
     /// Output peripheral
     Output(Box<dyn Output>),
 }

--- a/achiever/src/body/inputs.rs
+++ b/achiever/src/body/inputs.rs
@@ -2,6 +2,15 @@
 
 /// A trait for inputs, defines a single method for polling the peripheral's data
 pub trait Input {
-    /// Read bytes from peripheral to output
-    fn read(&mut self) -> Vec<u8>;
+    /// The error read_input may return
+    type Error;
+    /// Read bytes from peripheral entirely to an output buffer
+    /// Note* This means that if the buffer is larger than one read, it will read again
+    fn read_input(&mut self, buf: &mut [u8]) -> Result<(), Self::Error>;
 }
+
+#[cfg(feature = "rpi")]
+pub mod rpi_inputs;
+
+#[cfg(feature = "jetson")]
+pub mod jetson_inputs;

--- a/achiever/src/body/inputs/jetson_inputs.rs
+++ b/achiever/src/body/inputs/jetson_inputs.rs
@@ -1,0 +1,1 @@
+//! Input Trait Implementations for the Jetson Orin Nano

--- a/achiever/src/body/inputs/rpi_inputs.rs
+++ b/achiever/src/body/inputs/rpi_inputs.rs
@@ -1,0 +1,41 @@
+//! Input Implementations for Raspberry Pi Peripherals
+
+use std::convert::Infallible;
+
+use rppal::{gpio::InputPin, i2c::I2c, spi::Spi, uart::Uart};
+
+use super::Input;
+
+impl Input for InputPin {
+    type Error = Infallible;
+    fn read_input(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        for loc in buffer {
+            *loc = self.read() as u8
+        }
+        Ok(())
+    }
+}
+
+impl Input for I2c {
+    type Error = rppal::i2c::Error;
+    fn read_input(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        self.read(buf)?;
+        Ok(())
+    }
+}
+
+impl Input for Spi {
+    type Error = rppal::spi::Error;
+    fn read_input(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        self.read(buf)?;
+        Ok(())
+    }
+}
+
+impl Input for Uart {
+    type Error = rppal::uart::Error;
+    fn read_input(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        self.read(buf)?;
+        Ok(())
+    }
+}

--- a/achiever/src/body/outputs.rs
+++ b/achiever/src/body/outputs.rs
@@ -2,8 +2,10 @@
 
 /// A trait for outputs, defines a single method for writing bytes to an output
 pub trait Output {
+    /// The error read_input may return
+    type Error;
     /// Write bytes to an output peripheral
-    fn write(&mut self, bytes: &[u8]);
+    fn write(&mut self, bytes: &[u8]) -> Result<(), Self::Error>;
 }
 
 #[cfg(feature = "rpi")]

--- a/achiever/src/body/outputs.rs
+++ b/achiever/src/body/outputs.rs
@@ -5,3 +5,9 @@ pub trait Output {
     /// Write bytes to an output peripheral
     fn write(&mut self, bytes: &[u8]);
 }
+
+#[cfg(feature = "rpi")]
+pub mod rpi_outputs;
+
+#[cfg(feature = "jetson")]
+pub mod jetson_outputs;

--- a/achiever/src/body/outputs/jetson_outputs.rs
+++ b/achiever/src/body/outputs/jetson_outputs.rs
@@ -1,0 +1,1 @@
+//! Output Trait Implementations for the Jetson Orin Nano

--- a/achiever/src/body/outputs/rpi_outputs.rs
+++ b/achiever/src/body/outputs/rpi_outputs.rs
@@ -1,0 +1,1 @@
+//! Output Implementations for Raspberry Pi Output Peripherals

--- a/achiever/src/body/outputs/rpi_outputs.rs
+++ b/achiever/src/body/outputs/rpi_outputs.rs
@@ -1,1 +1,50 @@
 //! Output Implementations for Raspberry Pi Output Peripherals
+
+use std::convert::Infallible;
+
+use rppal::{
+    gpio::{Level, OutputPin},
+    i2c::I2c,
+    spi::Spi,
+    uart::Uart,
+};
+
+use super::Output;
+
+impl Output for OutputPin {
+    type Error = Infallible;
+    fn write(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+        for byte in bytes {
+            let state = match byte {
+                0..=127 => Level::Low,
+                _ => Level::High,
+            };
+            self.write(state)
+        }
+        Ok(())
+    }
+}
+
+impl Output for I2c {
+    type Error = rppal::i2c::Error;
+    fn write(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.write(bytes)?;
+        Ok(())
+    }
+}
+
+impl Output for Spi {
+    type Error = rppal::spi::Error;
+    fn write(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.write(bytes)?;
+        Ok(())
+    }
+}
+
+impl Output for Uart {
+    type Error = rppal::uart::Error;
+    fn write(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.write(bytes)?;
+        Ok(())
+    }
+}

--- a/achiever/src/lib.rs
+++ b/achiever/src/lib.rs
@@ -1,6 +1,9 @@
 //! The Agent/Data Collection Unit. Collects metadata into a buffer and sends it away to the local
 //! or cloud server, where it then receives a testable moveset and performs it accordingly
 
+#[cfg(all(feature = "jetson", feature = "rpi"))]
+compile_error! {"Jetson Nano and Raspberry Pi cannot both be targetted by the same sysetem"}
+
 pub mod body;
 pub mod brain;
 pub mod goals;


### PR DESCRIPTION
This PR introduces new functionality to support both Jetson Orin Nano and Raspberry Pi hardware in the `achiever` project. It includes updated traits for input and output peripherals and error handling for hardware-specific implementations. The addition of feature flags ensures compatibility with different target systems.
Changes:

    ✨ [Cargo.toml]: Added new feature flags (jetson, rpi) to conditionally compile hardware-specific code for either Jetson Orin Nano or Raspberry Pi.
    🔧 [body.rs]: Improved error handling for Peripheral enum by making Input and Output variants handle dynamic errors (Box<dyn Error>).
    ✨ [inputs.rs, outputs.rs]: Added implementations of Input and Output traits for Raspberry Pi using the rppal crate, and for Jetson with future extensibility.
    🔧 [agent.rs]: Updated act method to propagate errors from output peripherals via the newly introduced Result type.
    📝 [lib.rs]: Introduced a compile-time error if both jetson and rpi features are enabled simultaneously.

Features:

    🚀 Jetson and Raspberry Pi Support: Enables interaction with GPIO, I2C, SPI, and UART peripherals on both platforms.
    ⚠️ Enhanced Error Handling: Ensures that read/write operations on peripherals return meaningful error types, improving system robustness.
    🧩 Configurable via Features: Users can now target either Jetson or Raspberry Pi by setting the appropriate feature flag (rpi or jetson).

Additional Notes:

    🐛 A safeguard has been added to prevent compiling for both Jetson and Raspberry Pi at the same time (compile_error! in lib.rs).