### PR TITLE
feat: initial workings of simulation executor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "earthmover-achiever","earthmover-hivemind"]
+members = [ "earthmover-achiever","earthmover-hivemind", "earthmover-simulation"]
 resolver = "2"
 
 [workspace.package]

--- a/earthmover-simulation/Cargo.toml
+++ b/earthmover-simulation/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "earthmover-simulation"
+edition = "2021"
+version.workspace = true
+authors.workspace = true
+
+[dependencies]
+futures = "0.3.30"
+
+[lints.rust]
+missing_docs = "warn"
+nonstandard-style = "warn"
+rust-2018-idioms = "warn"
+rust-2021-compatibility = "warn"
+rust-2024-compatibility = "warn"
+
+[lints.rustdoc]
+broken_intra_doc_links = "warn"
+
+[lints.clippy]
+missing_docs_in_private_items = "warn"

--- a/earthmover-simulation/src/lib.rs
+++ b/earthmover-simulation/src/lib.rs
@@ -1,0 +1,27 @@
+//! The simulation enviornment responsible for constructing and interpretting collected data from
+//! the `agent`. Allows for concurrent reinforcement learning and modular agent construction
+//! through URDF parsing to interpret agent structure. 
+
+use std::{future::Future, pin::Pin};
+
+use futures::stream::FuturesUnordered;
+use sim::{SimArgs, SimRes};
+
+pub mod sim;
+pub mod orchestrate;
+
+type SimulationExecution<OUT> = Pin<Box<dyn Future<Output = OUT> + Send>>;
+
+/// Asynchronous function responsible for constructing and then simulating an environment given a
+/// collection of N-dimensional points, an agent's configuration(hardware alongside current
+/// angles/position) and a `GOAL` function
+pub async fn simulate<const N: usize>(args: impl AsRef<SimArgs>) -> SimRes {
+    let _sim_args = args.as_ref();
+
+    todo!()
+}
+
+/// The struct responsible for running a collection of N simulations
+pub struct Orchestrator<const N: usize> {
+    batch_sims: FuturesUnordered<SimulationExecution<SimRes>>,
+}

--- a/earthmover-simulation/src/lib.rs
+++ b/earthmover-simulation/src/lib.rs
@@ -1,15 +1,16 @@
 //! The simulation enviornment responsible for constructing and interpretting collected data from
 //! the `agent`. Allows for concurrent reinforcement learning and modular agent construction
-//! through URDF parsing to interpret agent structure. 
+//! through URDF parsing to interpret agent structure.
 
 use std::{future::Future, pin::Pin};
 
 use futures::stream::FuturesUnordered;
 use sim::{SimArgs, SimRes};
 
-pub mod sim;
 pub mod orchestrate;
+pub mod sim;
 
+/// The future responsible for fully executing a simulation
 type SimulationExecution<OUT> = Pin<Box<dyn Future<Output = OUT> + Send>>;
 
 /// Asynchronous function responsible for constructing and then simulating an environment given a
@@ -23,5 +24,6 @@ pub async fn simulate<const N: usize>(args: impl AsRef<SimArgs>) -> SimRes {
 
 /// The struct responsible for running a collection of N simulations
 pub struct Orchestrator<const N: usize> {
+    /// All simulations currently being run
     batch_sims: FuturesUnordered<SimulationExecution<SimRes>>,
 }

--- a/earthmover-simulation/src/orchestrate.rs
+++ b/earthmover-simulation/src/orchestrate.rs
@@ -1,0 +1,23 @@
+//! The implementation for generating a batch of simulations and running them
+
+use futures::{FutureExt, StreamExt};
+
+use crate::{sim::SimRes, simulate, Orchestrator};
+
+impl<const N: usize> Orchestrator<N> {
+    /// Submits `sim_amount` simulations to the Orchestrator for execution
+    pub fn submit(&mut self, sim_amount: usize) {
+        let fut = (0..sim_amount).into_iter().map(|_| simulate::<N>("todo").boxed());
+        self.batch_sims.extend(fut)
+    }
+
+    /// Runs all batch simulations and returns the simulation with the best fitness
+    pub async fn run(&mut self) -> SimRes {
+        let mut results = vec![];
+        while let Some(result) = self.batch_sims.next().await {
+            results.push(result);
+        }
+
+        todo!("Process the returned SimReses and find the one with the best fitness");
+    }
+}

--- a/earthmover-simulation/src/orchestrate.rs
+++ b/earthmover-simulation/src/orchestrate.rs
@@ -7,7 +7,7 @@ use crate::{sim::SimRes, simulate, Orchestrator};
 impl<const N: usize> Orchestrator<N> {
     /// Submits `sim_amount` simulations to the Orchestrator for execution
     pub fn submit(&mut self, sim_amount: usize) {
-        let fut = (0..sim_amount).into_iter().map(|_| simulate::<N>("todo").boxed());
+        let fut = (0..sim_amount).map(|_| simulate::<N>("todo").boxed());
         self.batch_sims.extend(fut)
     }
 

--- a/earthmover-simulation/src/sim.rs
+++ b/earthmover-simulation/src/sim.rs
@@ -1,0 +1,13 @@
+//! The arguments to be passed through to a simulation and outputs that can be returned
+
+/// Any agruments that a simulation may take in
+pub struct SimArgs;
+
+impl AsRef<SimArgs> for &str {
+    fn as_ref(&self) -> &SimArgs {
+        todo!()
+    }
+}
+
+/// The output from a simulation's runtime
+pub struct SimRes;


### PR DESCRIPTION
Small PR to show off the initial design I have for the simulation engine. Basically we have this `simulate` function that will take in all of the args necessary to create a standalone simulation (all points in n-space, agent's body,  agent's configuration) and generate the simulation. It will then go through some set of cycles to find the best fitness it thinks it can find. It will return this fitness value along with a set of instructions to reach that value as a `SimRes` struct. 

The `Orchestrator` is able to create and execute several of these simulations in parallel. It has a function for loading these simulations where it will add some amount of them to a `FuturesUnordered`. It then has a `run` method for awaiting the execution of all of these simulations, evaluating the fitness of each, and selecting the best one. 

There's still a lot of work here for the simulation stuff, but I wanted to show my initial thoughts on design before I went too forward with anything.  