### PR TITLE
feat: Generic Simulation Runner Service

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0
       - name: Update Rust
         run: rustup update nightly && rustup default nightly
       - name: Install rustfmt
@@ -21,6 +23,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - name: Install clippy
@@ -31,6 +35,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - run: cargo test
@@ -39,6 +45,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - run: cargo test --features rpi
@@ -47,6 +55,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - run: cargo test --features jetson
@@ -55,6 +65,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - run: cargo test --examples
@@ -63,6 +75,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - run: cargo doc

--- a/earthmover-achiever/src/brain/instruction.rs
+++ b/earthmover-achiever/src/brain/instruction.rs
@@ -3,6 +3,7 @@
 use crate::body::PeripheralKey;
 
 /// A single instruction of movement for an Agent
+#[derive(Default, Debug)]
 pub struct Instruction {
     /// The node affected by the instruction
     pub node: PeripheralKey,

--- a/earthmover-achiever/src/goals.rs
+++ b/earthmover-achiever/src/goals.rs
@@ -31,7 +31,7 @@ impl<REWARD: Rewardable> Goal<REWARD> {
 
 /// Basic implementations of reward function for primitive types that make sense
 ///
-pub trait Rewardable {
+pub trait Rewardable: Send + Sync {
     /// Returns an implementation's 'reward value' as an f64
     fn to_reward(&self) -> f64;
 }

--- a/earthmover-simulation/Cargo.toml
+++ b/earthmover-simulation/Cargo.toml
@@ -8,6 +8,8 @@ authors.workspace = true
 bevy = "0.14.2"
 bevy_rapier3d = "0.27.0"
 futures = "0.3.30"
+earthmover-achiever = { path = "../earthmover-achiever" }
+tokio = { version = "1.40.0", features = ["full"] }
 
 [lints.rust]
 missing_docs = "warn"

--- a/earthmover-simulation/Cargo.toml
+++ b/earthmover-simulation/Cargo.toml
@@ -5,6 +5,8 @@ version.workspace = true
 authors.workspace = true
 
 [dependencies]
+bevy = "0.14.2"
+bevy_rapier3d = "0.27.0"
 futures = "0.3.30"
 
 [lints.rust]

--- a/earthmover-simulation/src/lib.rs
+++ b/earthmover-simulation/src/lib.rs
@@ -4,6 +4,7 @@
 
 use std::{future::Future, pin::Pin};
 
+use bevy::app::App;
 use futures::stream::FuturesUnordered;
 use sim::{SimArgs, SimRes};
 
@@ -19,6 +20,7 @@ type SimulationExecution<OUT> = Pin<Box<dyn Future<Output = OUT> + Send>>;
 pub async fn simulate<const N: usize>(args: impl AsRef<SimArgs>) -> SimRes {
     let _sim_args = args.as_ref();
 
+    App::new().run();
     todo!()
 }
 

--- a/earthmover-simulation/src/orchestrate.rs
+++ b/earthmover-simulation/src/orchestrate.rs
@@ -30,6 +30,6 @@ impl<const N: usize> Orchestrator<N> {
             results.push(result);
         }
 
-        todo!("Process the returned SimReses and find the one with the best fitness");
+        results.into_iter().max().unwrap()
     }
 }

--- a/earthmover-simulation/src/sim.rs
+++ b/earthmover-simulation/src/sim.rs
@@ -1,13 +1,52 @@
 //! The arguments to be passed through to a simulation and outputs that can be returned
 
-/// Any agruments that a simulation may take in
-pub struct SimArgs;
+use std::sync::Arc;
 
-impl AsRef<SimArgs> for &str {
-    fn as_ref(&self) -> &SimArgs {
-        todo!()
+use earthmover_achiever::{
+    brain::{agent::Untrained, instruction::Instruction, AgentSession},
+    goals::Rewardable,
+};
+
+/// Any agruments that a simulation may take in
+pub struct SimArgs<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize>(
+    pub Arc<AgentSession<'agent, REWARD, Untrained, BUFFER_SIZE>>,
+);
+
+impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize>
+    Into<SimArgs<'agent, REWARD, BUFFER_SIZE>>
+    for AgentSession<'agent, REWARD, Untrained, BUFFER_SIZE>
+{
+    fn into(self) -> SimArgs<'agent, REWARD, BUFFER_SIZE> {
+        let arc_self = Arc::new(self);
+        SimArgs(arc_self)
     }
 }
 
 /// The output from a simulation's runtime
-pub struct SimRes;
+#[derive(Default, Debug)]
+pub struct SimRes {
+    /// The agent's score
+    score: f64,
+    /// The instructions to achieve this score
+    instructions: Vec<Instruction>,
+}
+
+impl SimRes {
+    /// Adds a new instruction to the back of the instruction set
+    pub fn push_instruction(&mut self, instruction: Instruction) {
+        self.instructions.push(instruction)
+    }
+
+    /// Sets the agents score for the provided instructions
+    pub fn set_score(&mut self, score: f64) {
+        self.score = score
+    }
+}
+
+/// A message coming back from a simulation
+pub enum SimMessage {
+    /// A new instruction
+    Instruction(Instruction),
+    /// Simulation has ended with a given score
+    Close(f64),
+}

--- a/earthmover-simulation/src/sim.rs
+++ b/earthmover-simulation/src/sim.rs
@@ -1,5 +1,7 @@
 //! The arguments to be passed through to a simulation and outputs that can be returned
 
+pub mod backend;
+
 use std::sync::Arc;
 
 use earthmover_achiever::{
@@ -30,6 +32,26 @@ pub struct SimRes {
     /// The instructions to achieve this score
     instructions: Vec<Instruction>,
 }
+
+impl PartialOrd for SimRes {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.score.partial_cmp(&other.score)
+    }
+}
+
+impl Ord for SimRes {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+impl PartialEq for SimRes {
+    fn eq(&self, other: &Self) -> bool {
+        self.score == other.score
+    }
+}
+
+impl Eq for SimRes {}
 
 impl SimRes {
     /// Adds a new instruction to the back of the instruction set

--- a/earthmover-simulation/src/sim/backend.rs
+++ b/earthmover-simulation/src/sim/backend.rs
@@ -1,0 +1,16 @@
+//! Trait for defining how a simulation is handled, through for example Bevy simulations
+
+use std::sync::Arc;
+
+use earthmover_achiever::goals::Rewardable;
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::{SimArgs, SimMessage};
+
+/// A simulation that takes in physical context and creates an instruction-set and final fitness
+/// score
+pub trait Simulation {
+    /// Runs through a simulation based on beginning arguments, reports back to a Receiver with
+    /// instructions to reach a certain `Score`
+    fn simulate<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize>(&self, args: Arc<SimArgs<'agent, REWARD, BUFFER_SIZE>>, message_sender: UnboundedSender<SimMessage>);
+}

--- a/earthmover-simulation/src/sim/backend.rs
+++ b/earthmover-simulation/src/sim/backend.rs
@@ -12,5 +12,9 @@ use super::{SimArgs, SimMessage};
 pub trait Simulation {
     /// Runs through a simulation based on beginning arguments, reports back to a Receiver with
     /// instructions to reach a certain `Score`
-    fn simulate<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize>(&self, args: Arc<SimArgs<'agent, REWARD, BUFFER_SIZE>>, message_sender: UnboundedSender<SimMessage>);
+    fn simulate<REWARD: Rewardable>(
+        &self,
+        args: Arc<SimArgs<REWARD>>,
+        message_sender: UnboundedSender<SimMessage>,
+    );
 }


### PR DESCRIPTION
This PR introduces a finished implementation of the simulation side of `Earthmover`, with a simulation engine agnostic runtime. This is done by defining a trait for any simulation backend, which in our case will likely be either rapier or bevy. The function itself is ran by an `Orchestrator` that can run a set amount of simulations and aggregate the most 'fit' simulation for a future batch. The simulation method passes in a send channel for new instructions and the final fitness of the model.

✨ New Features:

- Added a new field to the Instruction struct to support more comprehensive movement commands for agents.
- Introduced a new Simulation trait, abstracting away the simulation backend logic for flexibility.

♻️ Refactor:

- Updated the simulate function to support multiple backend simulation types using generics.
- Refined the `Orchestrator` struct to support complex simulation management and batch processing.
- Enhanced SimRes to support comparisons and ordered ranking based on results.


🔨 Improvements:

- Modified the `Rewardable` trait by adding Send and Sync bounds, ensuring thread safety for async contexts for execution in parallel.