### PR TITLE
Feat: ArrowHead Transfer Protocol Implemented in Agent

### DIFF
--- a/earthmover-achiever/Cargo.toml
+++ b/earthmover-achiever/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 
 [dependencies]
 clap = { version = "4.5.18", features = ["derive"] }
+futures-util = "0.3.31"
 reqwest = { version = "0.12.8" }
 rppal = { version = "0.19.0", optional = true }
 serde = { version = "1.0.210", features = ["derive"] }
@@ -13,6 +14,7 @@ serde_json = "1.0.128"
 slotmap = { version = "1.0.7", features = ["serde"] }
 thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["full"] }
+tokio-tungstenite = "0.24.0"
 urlencoding = "2.1.3"
 uuid = { version = "1.10.0", features = ["v4"] }
 

--- a/earthmover-achiever/Cargo.toml
+++ b/earthmover-achiever/Cargo.toml
@@ -7,7 +7,9 @@ authors.workspace = true
 [dependencies]
 clap = { version = "4.5.18", features = ["derive"] }
 rppal = { version = "0.19.0", optional = true }
-slotmap = "1.0.7"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"
+slotmap = { version = "1.0.7", features = ["serde"] }
 thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["full"] }
 uuid = { version = "1.10.0", features = ["v4"] }

--- a/earthmover-achiever/Cargo.toml
+++ b/earthmover-achiever/Cargo.toml
@@ -6,12 +6,14 @@ authors.workspace = true
 
 [dependencies]
 clap = { version = "4.5.18", features = ["derive"] }
+reqwest = { version = "0.12.8" }
 rppal = { version = "0.19.0", optional = true }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 slotmap = { version = "1.0.7", features = ["serde"] }
 thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["full"] }
+urlencoding = "2.1.3"
 uuid = { version = "1.10.0", features = ["v4"] }
 
 [features]

--- a/earthmover-achiever/Cargo.toml
+++ b/earthmover-achiever/Cargo.toml
@@ -10,6 +10,7 @@ rppal = { version = "0.19.0", optional = true }
 slotmap = "1.0.7"
 thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["full"] }
+uuid = { version = "1.10.0", features = ["v4"] }
 
 [features]
 default = []

--- a/earthmover-achiever/src/brain/instruction.rs
+++ b/earthmover-achiever/src/brain/instruction.rs
@@ -1,9 +1,11 @@
 //! Movement instructions for an Agent's Body
 
+use serde::{Deserialize, Serialize};
+
 use crate::body::PeripheralKey;
 
 /// A single instruction of movement for an Agent
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Instruction {
     /// The node affected by the instruction
     pub node: PeripheralKey,

--- a/earthmover-achiever/src/goals.rs
+++ b/earthmover-achiever/src/goals.rs
@@ -15,6 +15,8 @@ pub enum Goal<REWARD: Rewardable> {
     Maximize(REWARD),
     /// Minimize this Reward's value
     Minimize(REWARD),
+    /// A combination of goals
+    Complex(Vec<Goal<REWARD>>),
     /// No goal
     None,
 }
@@ -24,6 +26,14 @@ impl<REWARD: Rewardable> Goal<REWARD> {
     pub fn evaluate(&self) -> Option<f64> {
         match self {
             Self::Maximize(reward) | Self::Minimize(reward) => Some(reward.to_reward()),
+            Self::Complex(goals) => {
+                let mut res = 0.0;
+                for goal in goals {
+                    res += goal.evaluate()?;
+                }
+
+                Some(res)
+            }
             Self::None => None,
         }
     }

--- a/earthmover-achiever/src/lib.rs
+++ b/earthmover-achiever/src/lib.rs
@@ -7,3 +7,4 @@ compile_error! {"Jetson Nano and Raspberry Pi cannot both be targetted by the sa
 pub mod body;
 pub mod brain;
 pub mod goals;
+pub mod protocol;

--- a/earthmover-achiever/src/main.rs
+++ b/earthmover-achiever/src/main.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use earthmover_achiever::brain::agent::Untrained;
 use earthmover_achiever::goals::Goal;
+use earthmover_achiever::protocol::AhtpResponse;
 use earthmover_achiever::{body::Body, brain::AgentSession};
 
 #[derive(Parser, Debug)]
@@ -16,6 +17,9 @@ struct Config {
     #[arg(short = 'g', long = "with-goals", value_delimiter=' ', num_args = 1..)]
     /// An arbitrary list of usize/bool alternating pairs to create basic goals for the agent
     with_goals: Option<Vec<String>>,
+    #[arg(short = 't', long = "threshold")]
+    /// The threshold for when the fitness is acceptable
+    threshold: f32,
     #[arg(short = 's', long = "server")]
     /// An optional server to bind to
     server: Option<String>,
@@ -39,11 +43,49 @@ pub async fn main() {
     let mut body = body.unwrap();
     let goals = goals.unwrap();
 
+    let _threshold = args.threshold;
+    let server_to = args.server.unwrap_or("0.0.0.0:1940".into());
+
     let _agent = AgentSession::<_, Untrained, 100_000>::builder()
         .with_body(&mut body)
         .with_goal(Goal::Complex(goals))
         .build()
         .unwrap();
 
-    loop {}
+    // Connect to server
+    let body_serialized = "todo";
+    let body_encoded = urlencoding::encode(body_serialized);
+    let connection = format!("http://{}/initiate?urdf={}", server_to, body_encoded);
+
+    let response = reqwest::get(connection)
+        .await
+        .expect("Failed to send request to server for initiation");
+
+    if !response.status().is_success() {
+        panic!("Failed to initiate server connection")
+    }
+
+    let response = response
+        .text()
+        .await
+        .expect("Failed to fetch response body");
+    let response_ahtp: AhtpResponse =
+        serde_json::from_str(&response).expect("Failed to deserialize response");
+
+    let _id = response_ahtp
+        .get_init()
+        .expect("Response wasn't an initialization");
+    // Now that we have ID, we can initialize a websocket connection
+
+    let _conditions_reached = false;
+    loop {
+        // Collect all data until buffer is full
+
+        // Check assess fitness, if past threshold set conditions_reached to true and break
+
+        // Send buffer out to hivemind server and await update to instructions.
+
+        // Perform instructions
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 }

--- a/earthmover-achiever/src/main.rs
+++ b/earthmover-achiever/src/main.rs
@@ -3,6 +3,9 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use earthmover_achiever::brain::agent::Untrained;
+use earthmover_achiever::goals::Goal;
+use earthmover_achiever::{body::Body, brain::AgentSession};
 
 #[derive(Parser, Debug)]
 /// Configuration for the achiever session from the CLI
@@ -18,10 +21,29 @@ struct Config {
     server: Option<String>,
 }
 
+impl Config {
+    /// Parses a config into an agent's Body and Goals
+    pub fn get_body_and_goals(&self) -> (Option<Body>, Option<Vec<Goal<f32>>>) {
+        todo!()
+    }
+}
+
 /// Initializes an achiever system via a URDF file parsed into a `Body` and any arbitrary goals set
 /// through the CLI
 #[tokio::main]
 pub async fn main() {
     let args = Config::parse();
-    println!("Todo: Parse These Args into a Body and a Goal:\n{:?}", args);
+
+    //Todo: Parse These Args into a Body and a Goal
+    let (body, goals) = args.get_body_and_goals();
+    let mut body = body.unwrap();
+    let goals = goals.unwrap();
+
+    let _agent = AgentSession::<_, Untrained, 100_000>::builder()
+        .with_body(&mut body)
+        .with_goal(Goal::Complex(goals))
+        .build()
+        .unwrap();
+
+    loop {}
 }

--- a/earthmover-achiever/src/main.rs
+++ b/earthmover-achiever/src/main.rs
@@ -30,7 +30,7 @@ struct Config {
 
 impl Config {
     /// Parses a config into an agent's Body and Goals
-    pub fn get_body_and_goals(&self) -> (Option<Body>, Option<Vec<Goal<f32>>>) {
+    pub fn get_body_and_goals(&self) -> (Option<Body>, Option<Goal<f32>>) {
         todo!()
     }
 }
@@ -51,7 +51,7 @@ pub async fn main() {
 
     let _agent = AgentSession::<_, Untrained, 100_000>::builder()
         .with_body(&mut body)
-        .with_goal(Goal::Complex(goals))
+        .with_goal(goals)
         .build()
         .unwrap();
 

--- a/earthmover-achiever/src/protocol.rs
+++ b/earthmover-achiever/src/protocol.rs
@@ -1,6 +1,8 @@
+//! Enum and Struct definitions for the *ArrowHead Transfer Protocol*
+
+use crate::brain::instruction::Instruction;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use uuid::Uuid;
-use crate::brain::instruction::Instruction;
 
 /// A message to send to an already initialized AHTP accepting simulation server. This must first
 /// be initialized by sending an initiation request with respect to serialized URDF and agent body
@@ -33,7 +35,8 @@ pub enum AhtpResponse {
 /// A trait to indicate that array sizes are bounded.
 pub trait ArrayBoundedSize {}
 
-// Macro to implement ArrayBoundedSize for `[f32; N]` arrays up to the specified maximum size.
+/// Macro to implement ArrayBoundedSize for `[f32; N]` arrays up to the specified maximum size.
+#[allow(edition_2024_expr_fragment_specifier)]
 macro_rules! impl_array_bounded_size {
     ($($size:expr),*) => {
         $(impl ArrayBoundedSize for [f32; $size] {} )*
@@ -41,4 +44,7 @@ macro_rules! impl_array_bounded_size {
 }
 
 // Implement ArrayBoundedSize for arrays of size 0 to 32.
-impl_array_bounded_size!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
+impl_array_bounded_size!(
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+    26, 27, 28, 29, 30, 31, 32
+);

--- a/earthmover-achiever/src/protocol.rs
+++ b/earthmover-achiever/src/protocol.rs
@@ -1,0 +1,28 @@
+//! Enum and Struct definitions for the *ArrowHead Transfer Protocol*
+
+use uuid::Uuid;
+
+use crate::brain::instruction::Instruction;
+
+/// A message to send to an already initialized AHTP accepting simulation server. This must first
+/// be initialized by sending an initiation request with respect to serialized urdf and agent body
+/// information
+pub enum AhtpMessage<const DIMS: usize> {
+    /// Send a buffer of collected data points to the server in DIMS dimensions
+    Send(Vec<[f32; DIMS]>),
+    /// Set the current goal of the agent. That is, what index of dimension do we want to
+    /// maximize(true) or minimize(false). 
+    ///
+    /// For example, `Goal([(0, true)])` would attempt to maximize the first dimension on the
+    /// agent's readings.
+    GOAL(Vec<(usize, bool)>)
+}
+
+/// A response from the simulation server
+pub enum AhtpResponse {
+    /// The initialization step was a success, here is the session ID to init websocket
+    /// communication with.
+    Initialized(Uuid),
+    /// An instruction set from the simulation server
+    Instruction(Vec<Instruction>)
+}

--- a/earthmover-achiever/src/protocol.rs
+++ b/earthmover-achiever/src/protocol.rs
@@ -24,6 +24,16 @@ where
     Goal(Vec<(usize, bool)>),
 }
 
+impl<const DIMS: usize> AhtpMessage<DIMS>
+where
+    [f32; DIMS]: ArrayBoundedSize + Serialize + DeserializeOwned,
+{
+    /// Serializes the message as a json string
+    pub fn to_json_string(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+}
+
 /// A response from the simulation server.
 #[derive(Serialize, Deserialize)]
 pub enum AhtpResponse {

--- a/earthmover-achiever/src/protocol.rs
+++ b/earthmover-achiever/src/protocol.rs
@@ -19,7 +19,7 @@ where
     ///
     /// For example, `Goal([(0, true)])` would attempt to maximize the first dimension on the
     /// agent's readings.
-    GOAL(Vec<(usize, bool)>),
+    Goal(Vec<(usize, bool)>),
 }
 
 /// A response from the simulation server.
@@ -48,3 +48,23 @@ impl_array_bounded_size!(
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
     26, 27, 28, 29, 30, 31, 32
 );
+
+// Some helpful stuff for creating messages conveniently
+
+impl<const DIMS: usize> From<Vec<(usize, bool)>> for AhtpMessage<DIMS>
+where
+    [f32; DIMS]: ArrayBoundedSize + Serialize + DeserializeOwned,
+{
+    fn from(value: Vec<(usize, bool)>) -> Self {
+        Self::Goal(value)
+    }
+}
+
+impl<const DIMS: usize> From<Vec<[f32; DIMS]>> for AhtpMessage<DIMS>
+where
+    [f32; DIMS]: ArrayBoundedSize + Serialize + DeserializeOwned,
+{
+    fn from(value: Vec<[f32; DIMS]>) -> Self {
+        Self::Send(value)
+    }
+}

--- a/earthmover-achiever/src/protocol.rs
+++ b/earthmover-achiever/src/protocol.rs
@@ -14,6 +14,8 @@ where
 {
     /// Send a buffer of collected data points to the server in DIMS dimensions.
     Send(Vec<[f32; DIMS]>),
+    /// Connect to a session via websocket
+    Connect(Uuid),
     /// Set the current goal of the agent. That is, which index of dimension we want to
     /// maximize (true) or minimize (false).
     ///
@@ -30,6 +32,16 @@ pub enum AhtpResponse {
     Initialized(Uuid),
     /// An instruction set from the simulation server.
     Instruction(Vec<Instruction>),
+}
+
+impl AhtpResponse {
+    /// Returns the initialized ID if the type of this response is an init
+    pub fn get_init(self) -> Option<Uuid> {
+        match self {
+            Self::Initialized(id) => Some(id),
+            _ => None,
+        }
+    }
 }
 
 /// A trait to indicate that array sizes are bounded.

--- a/earthmover-achiever/src/protocol.rs
+++ b/earthmover-achiever/src/protocol.rs
@@ -1,28 +1,44 @@
-//! Enum and Struct definitions for the *ArrowHead Transfer Protocol*
-
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use uuid::Uuid;
-
 use crate::brain::instruction::Instruction;
 
 /// A message to send to an already initialized AHTP accepting simulation server. This must first
-/// be initialized by sending an initiation request with respect to serialized urdf and agent body
-/// information
-pub enum AhtpMessage<const DIMS: usize> {
-    /// Send a buffer of collected data points to the server in DIMS dimensions
+/// be initialized by sending an initiation request with respect to serialized URDF and agent body
+/// information.
+#[derive(Serialize, Deserialize)]
+pub enum AhtpMessage<const DIMS: usize>
+where
+    [f32; DIMS]: ArrayBoundedSize + Serialize + DeserializeOwned,
+{
+    /// Send a buffer of collected data points to the server in DIMS dimensions.
     Send(Vec<[f32; DIMS]>),
-    /// Set the current goal of the agent. That is, what index of dimension do we want to
-    /// maximize(true) or minimize(false). 
+    /// Set the current goal of the agent. That is, which index of dimension we want to
+    /// maximize (true) or minimize (false).
     ///
     /// For example, `Goal([(0, true)])` would attempt to maximize the first dimension on the
     /// agent's readings.
-    GOAL(Vec<(usize, bool)>)
+    GOAL(Vec<(usize, bool)>),
 }
 
-/// A response from the simulation server
+/// A response from the simulation server.
+#[derive(Serialize, Deserialize)]
 pub enum AhtpResponse {
-    /// The initialization step was a success, here is the session ID to init websocket
+    /// The initialization step was a success. Here is the session ID to init WebSocket
     /// communication with.
     Initialized(Uuid),
-    /// An instruction set from the simulation server
-    Instruction(Vec<Instruction>)
+    /// An instruction set from the simulation server.
+    Instruction(Vec<Instruction>),
 }
+
+/// A trait to indicate that array sizes are bounded.
+pub trait ArrayBoundedSize {}
+
+// Macro to implement ArrayBoundedSize for `[f32; N]` arrays up to the specified maximum size.
+macro_rules! impl_array_bounded_size {
+    ($($size:expr),*) => {
+        $(impl ArrayBoundedSize for [f32; $size] {} )*
+    };
+}
+
+// Implement ArrayBoundedSize for arrays of size 0 to 32.
+impl_array_bounded_size!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);


### PR DESCRIPTION
This pull request introduces the *ArrowHead Transfer Protocol (AHTP)* for `agent` communication in the `earthmover-achiever` project. It integrates a structured messaging protocol that enables agent communication with a simulation server via HTTP and WebSocket. 🌐

Modified the Instruction struct to include Serialize and Deserialize traits, allowing it to be used in protocol communication.
Goals Handling 🧠:

- Extended the Goal enum to support complex goals.
- Added methods to evaluate and manage goals for the agent.

- Added the protocol.rs module to define the ArrowHead Transfer Protocol.
- Implemented AhtpMessage and AhtpResponse enums to handle data transmission:
- AhtpMessage can send data (Send), connect to a session (Connect), or set goals (Goal).
- AhtpResponse provides initialization (Initialized) or instructions (Instruction).
- Added helper functions to serialize/deserialize messages for communication.

Updated the main agent to use CLI arguments for configuration (e.g., goals, thresholds, server endpoint).
Implemented logic to:
- Parse CLI inputs into Body and Goal structures.
- Initialize the agent session via an HTTP connection.
- Set up WebSocket communication using AHTP messages.
- Continuously exchange data and perform actions based on server instructions.