### PR TITLE
Feat: Beginnings of The Physics Informed Simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+physics.exe

--- a/earthmover-simulation/Cargo.toml
+++ b/earthmover-simulation/Cargo.toml
@@ -14,6 +14,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 rapier3d = "0.22.0"
 indicatif = "0.17.8"
+rand = "0.8.5"
 
 [lints.rust]
 missing_docs = "warn"

--- a/earthmover-simulation/examples/one_simulation.rs
+++ b/earthmover-simulation/examples/one_simulation.rs
@@ -1,1 +1,0 @@
-pub fn main() {}

--- a/earthmover-simulation/examples/one_simulation.rs
+++ b/earthmover-simulation/examples/one_simulation.rs
@@ -1,0 +1,1 @@
+pub fn main() {}

--- a/earthmover-simulation/examples/physics.rs
+++ b/earthmover-simulation/examples/physics.rs
@@ -17,10 +17,10 @@ pub fn main() {
     let mut data = vec![];
 
     let mut rng = thread_rng();
-    for _ in 0..10_000 {
-        let x = rng.gen_range(-3f32..3f32);
-        let y = rng.gen_range(0f32..3f32);
-        let z = f32::cos(x);
+    for _ in 0..100_000 {
+        let x = rng.gen_range(-2f32..2f32);
+        let y = rng.gen_range(0f32..4f32);
+        let z = f32::cos(2.0 * x) / 5.0;
 
         data.push([x, y, z]);
     }

--- a/earthmover-simulation/examples/physics.rs
+++ b/earthmover-simulation/examples/physics.rs
@@ -17,10 +17,10 @@ pub fn main() {
     let mut data = vec![];
 
     let mut rng = thread_rng();
-    for _ in 0..100_000 {
+    for _ in 0..10_000 {
         let x = rng.gen_range(-2f32..2f32);
         let y = rng.gen_range(0f32..4f32);
-        let z = f32::cos(2.0 * x) / 5.0;
+        let z = f32::cos(2.0 * (x + y)) / 5.0;
 
         data.push([x, y, z]);
     }

--- a/earthmover-simulation/examples/physics.rs
+++ b/earthmover-simulation/examples/physics.rs
@@ -1,0 +1,31 @@
+//! Example for visualizing the Bevy physics simulation
+
+use earthmover_achiever::body::Body;
+use earthmover_simulation::sim::{
+    backend::{physics::BevyPhysicsInformedBackend, Simulation},
+    SimArgs,
+};
+use rand::{thread_rng, Rng};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+/// Runs the Bevy Simulation with default args
+pub fn main() {
+    let backend = BevyPhysicsInformedBackend;
+    let messages = mpsc::unbounded_channel();
+
+    let mut data = vec![];
+
+    let mut rng = thread_rng();
+    for _ in 0..10_000 {
+        let x = rng.gen_range(-3f32..3f32);
+        let y = rng.gen_range(0f32..3f32);
+        let z = f32::cos(x);
+
+        data.push([x, y, z]);
+    }
+
+    let args: SimArgs<f32, 3> = SimArgs::new(0f32, data, Body::default());
+
+    backend.simulate(Arc::new(args), messages.0)
+}

--- a/earthmover-simulation/src/lib.rs
+++ b/earthmover-simulation/src/lib.rs
@@ -6,7 +6,10 @@ use std::{future::Future, pin::Pin, sync::Arc};
 
 use earthmover_achiever::goals::Rewardable;
 use futures::stream::FuturesUnordered;
-use sim::{backend::Simulation, SimArgs, SimMessage, SimRes};
+use sim::{
+    backend::{Simulation, ValidDimension},
+    SimArgs, SimMessage, SimRes,
+};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 #[cfg(test)]
@@ -36,7 +39,10 @@ pub async fn simulate<
 >(
     simulation_backend: SIM,
     sim_args: Arc<SimArgs<REWARD, N>>,
-) -> SimRes {
+) -> SimRes
+where
+    [f32; N]: ValidDimension,
+{
     info!("Beginning simulation...");
     let mut res = SimRes::default();
     let (sender, mut receiver): (UnboundedSender<SimMessage>, UnboundedReceiver<SimMessage>) =

--- a/earthmover-simulation/src/lib.rs
+++ b/earthmover-simulation/src/lib.rs
@@ -35,7 +35,7 @@ pub async fn simulate<
     SIM: Simulation + Send + Sync + 'static,
 >(
     simulation_backend: SIM,
-    sim_args: Arc<SimArgs<REWARD>>,
+    sim_args: Arc<SimArgs<REWARD, N>>,
 ) -> SimRes {
     info!("Beginning simulation...");
     let mut res = SimRes::default();
@@ -74,9 +74,9 @@ struct SimpleBackend;
 
 #[cfg(test)]
 impl Simulation for SimpleBackend {
-    fn simulate<REWARD: Rewardable>(
+    fn simulate<REWARD: Rewardable, const DIMS: usize>(
         &self,
-        _args: Arc<SimArgs<REWARD>>,
+        _args: Arc<SimArgs<REWARD, DIMS>>,
         message_sender: UnboundedSender<SimMessage>,
     ) {
         let _ = tracing_subscriber::fmt::try_init();
@@ -105,9 +105,9 @@ struct SimplePhysicsBackend;
 
 #[cfg(test)]
 impl Simulation for SimplePhysicsBackend {
-    fn simulate<REWARD: Rewardable>(
+    fn simulate<REWARD: Rewardable, const DIMS: usize>(
         &self,
-        _args: Arc<SimArgs<REWARD>>,
+        _args: Arc<SimArgs<REWARD, DIMS>>,
         message_sender: UnboundedSender<SimMessage>,
     ) {
         let _ = tracing_subscriber::fmt::try_init();

--- a/earthmover-simulation/src/orchestrate.rs
+++ b/earthmover-simulation/src/orchestrate.rs
@@ -8,7 +8,10 @@ use indicatif::{ProgressBar, ProgressStyle};
 use tracing::info;
 
 use crate::{
-    sim::{backend::Simulation, SimArgs, SimRes},
+    sim::{
+        backend::{Simulation, ValidDimension},
+        SimArgs, SimRes,
+    },
     simulate, Orchestrator,
 };
 
@@ -18,7 +21,9 @@ impl<const N: usize, SIM: Simulation + Send + Sync + Copy + 'static> Orchestrato
         &mut self,
         job: SimArgs<REWARD, N>,
         sim_amount: usize,
-    ) {
+    ) where
+        [f32; N]: ValidDimension,
+    {
         info!(
             "Submitting {sim_amount} simulation requests to backend {}",
             self.simulation_backend.name()

--- a/earthmover-simulation/src/orchestrate.rs
+++ b/earthmover-simulation/src/orchestrate.rs
@@ -16,7 +16,7 @@ impl<const N: usize, SIM: Simulation + Send + Sync + Copy + 'static> Orchestrato
     /// Submits `sim_amount` simulations to the Orchestrator for execution
     pub fn submit<REWARD: Rewardable + Sync + Send + 'static>(
         &mut self,
-        job: SimArgs<REWARD>,
+        job: SimArgs<REWARD, N>,
         sim_amount: usize,
     ) {
         info!(

--- a/earthmover-simulation/src/sim.rs
+++ b/earthmover-simulation/src/sim.rs
@@ -7,29 +7,29 @@ use std::sync::Arc;
 use earthmover_achiever::{body::Body, brain::instruction::Instruction, goals::Rewardable};
 
 /// Any agruments that a simulation may take in
-pub struct SimArgs<REWARD: Rewardable + Send + Sync + 'static> {
+pub struct SimArgs<REWARD: Rewardable + Send + Sync + 'static, const DIMS: usize> {
     /// The simulation reward
     pub reward: REWARD,
     /// The data passed in
-    pub data: Vec<f32>,
+    pub data: Vec<[f32; DIMS]>,
     /// The agent's body
     pub body: Body,
 }
 
-impl<REWARD: Rewardable + Send + Sync + 'static> SimArgs<REWARD> {
+impl<REWARD: Rewardable + Send + Sync + 'static, const DIMS: usize> SimArgs<REWARD, DIMS> {
     /// Wraps self in an arc
-    pub fn arc(self) -> ArcSimArgs<REWARD> {
+    pub fn arc(self) -> ArcSimArgs<REWARD, DIMS> {
         Arc::new(self)
     }
 
     /// Creates a new SimArgs from raw parts
-    pub fn new(reward: REWARD, data: Vec<f32>, body: Body) -> Self {
+    pub fn new(reward: REWARD, data: Vec<[f32; DIMS]>, body: Body) -> Self {
         Self { reward, data, body }
     }
 }
 
 /// An arc-wrapped SimArg
-pub type ArcSimArgs<REWARD> = Arc<SimArgs<REWARD>>;
+pub type ArcSimArgs<REWARD, const DIMS: usize> = Arc<SimArgs<REWARD, DIMS>>;
 
 /// The output from a simulation's runtime
 #[derive(Default, Debug)]

--- a/earthmover-simulation/src/sim.rs
+++ b/earthmover-simulation/src/sim.rs
@@ -4,6 +4,7 @@ pub mod backend;
 
 use std::sync::Arc;
 
+use bevy::prelude::Resource;
 use earthmover_achiever::{body::Body, brain::instruction::Instruction, goals::Rewardable};
 
 /// Any agruments that a simulation may take in
@@ -19,7 +20,7 @@ pub struct SimArgs<REWARD: Rewardable + Send + Sync + 'static, const DIMS: usize
 impl<REWARD: Rewardable + Send + Sync + 'static, const DIMS: usize> SimArgs<REWARD, DIMS> {
     /// Wraps self in an arc
     pub fn arc(self) -> ArcSimArgs<REWARD, DIMS> {
-        Arc::new(self)
+        ArcSimArgs(Arc::new(self))
     }
 
     /// Creates a new SimArgs from raw parts
@@ -29,7 +30,10 @@ impl<REWARD: Rewardable + Send + Sync + 'static, const DIMS: usize> SimArgs<REWA
 }
 
 /// An arc-wrapped SimArg
-pub type ArcSimArgs<REWARD, const DIMS: usize> = Arc<SimArgs<REWARD, DIMS>>;
+#[derive(Resource)]
+pub struct ArcSimArgs<REWARD: Rewardable + Send + Sync + 'static, const DIMS: usize>(
+    pub Arc<SimArgs<REWARD, DIMS>>,
+);
 
 /// The output from a simulation's runtime
 #[derive(Default, Debug)]

--- a/earthmover-simulation/src/sim/backend.rs
+++ b/earthmover-simulation/src/sim/backend.rs
@@ -18,9 +18,26 @@ pub trait Simulation {
         &self,
         args: Arc<SimArgs<REWARD, DIMS>>,
         message_sender: UnboundedSender<SimMessage>,
-    );
+    ) where
+        [f32; DIMS]: ValidDimension;
     /// The backend's name
     fn name(&self) -> String {
         "Empty".into()
     }
 }
+
+/// Allows the ValidDimension trait for n dimensions
+#[allow(edition_2024_expr_fragment_specifier)]
+macro_rules! valid_for {
+    ($($dim:expr),+) => {
+        $(impl ValidDimension for [f32; $dim] {})+
+    };
+}
+
+/// Denotes if an n-dimensional point is valid in our engine. Currently, any dimension in the
+/// range 3 <= n <= 32 are considered valid dimensions
+pub trait ValidDimension {}
+valid_for!(
+    3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+    28, 29, 30, 31, 32
+);

--- a/earthmover-simulation/src/sim/backend.rs
+++ b/earthmover-simulation/src/sim/backend.rs
@@ -1,5 +1,7 @@
 //! Trait for defining how a simulation is handled, through for example Bevy simulations
 
+pub mod physics;
+
 use std::sync::Arc;
 
 use earthmover_achiever::goals::Rewardable;

--- a/earthmover-simulation/src/sim/backend.rs
+++ b/earthmover-simulation/src/sim/backend.rs
@@ -14,9 +14,9 @@ use super::{SimArgs, SimMessage};
 pub trait Simulation {
     /// Runs through a simulation based on beginning arguments, reports back to a Receiver with
     /// instructions to reach a certain `Score`
-    fn simulate<REWARD: Rewardable>(
+    fn simulate<REWARD: Rewardable, const DIMS: usize>(
         &self,
-        args: Arc<SimArgs<REWARD>>,
+        args: Arc<SimArgs<REWARD, DIMS>>,
         message_sender: UnboundedSender<SimMessage>,
     );
     /// The backend's name

--- a/earthmover-simulation/src/sim/backend/physics.rs
+++ b/earthmover-simulation/src/sim/backend/physics.rs
@@ -1,5 +1,7 @@
 //! Physics Informed Backend Implementation
 
+use std::sync::Arc;
+
 use bevy::{
     app::{App, Startup},
     asset::Assets,
@@ -9,9 +11,10 @@ use bevy::{
     prelude::{Camera3dBundle, Commands, Cuboid, Mesh, ResMut, Resource, Transform},
     utils::default,
 };
+use earthmover_achiever::goals::Rewardable;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::sim::SimMessage;
+use crate::sim::{SimArgs, SimMessage};
 
 use super::Simulation;
 
@@ -27,10 +30,10 @@ impl Simulation for BevyPhysicsInformedBackend {
         "Bevy-Based Physics Backend".into()
     }
 
-    fn simulate<REWARD: earthmover_achiever::goals::Rewardable>(
+    fn simulate<REWARD: Rewardable, const DIMS: usize>(
         &self,
-        _args: std::sync::Arc<crate::sim::SimArgs<REWARD>>,
-        message_sender: tokio::sync::mpsc::UnboundedSender<crate::sim::SimMessage>,
+        _args: Arc<SimArgs<REWARD, DIMS>>,
+        message_sender: tokio::sync::mpsc::UnboundedSender<SimMessage>,
     ) {
         App::new()
             .insert_resource(MessageChannel(message_sender))

--- a/earthmover-simulation/src/sim/backend/physics.rs
+++ b/earthmover-simulation/src/sim/backend/physics.rs
@@ -87,12 +87,12 @@ fn setup<REWARD: Rewardable, const DIMS: usize>(
     }
 
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, -2.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(0.0, -2.0, 1.0).looking_at(Vec3::ZERO, Vec3::Z),
         ..default()
     });
 
     commands.spawn(DirectionalLightBundle {
-        transform: Transform::from_xyz(3.0, 3.0, 3.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(3.0, 3.0, 3.0).looking_at(Vec3::ZERO, Vec3::Z),
         ..default()
     });
 }

--- a/earthmover-simulation/src/sim/backend/physics.rs
+++ b/earthmover-simulation/src/sim/backend/physics.rs
@@ -1,0 +1,66 @@
+//! Physics Informed Backend Implementation
+
+use bevy::{
+    app::{App, Startup},
+    asset::Assets,
+    color::Color,
+    math::Vec3,
+    pbr::{DirectionalLightBundle, PbrBundle, StandardMaterial},
+    prelude::{Camera3dBundle, Commands, Cuboid, Mesh, ResMut, Resource, Transform},
+    utils::default,
+};
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::sim::SimMessage;
+
+use super::Simulation;
+
+/// A Bevy Resource for the Mpsc Channel
+#[derive(Resource)]
+pub struct MessageChannel(pub UnboundedSender<SimMessage>);
+
+/// A Physics Informed Backend Runner
+pub struct BevyPhysicsInformedBackend;
+
+impl Simulation for BevyPhysicsInformedBackend {
+    fn name(&self) -> String {
+        "Bevy-Based Physics Backend".into()
+    }
+
+    fn simulate<REWARD: earthmover_achiever::goals::Rewardable>(
+        &self,
+        _args: std::sync::Arc<crate::sim::SimArgs<REWARD>>,
+        message_sender: tokio::sync::mpsc::UnboundedSender<crate::sim::SimMessage>,
+    ) {
+        App::new()
+            .insert_resource(MessageChannel(message_sender))
+            .add_systems(Startup, setup)
+            .run();
+    }
+}
+
+/// Sets up the bevy simulation world with respect to the points provided
+#[allow(unused_attributes)]
+#[allow(elided_lifetimes_in_paths)]
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn((PbrBundle {
+        mesh: meshes.add(Cuboid::default()),
+        material: materials.add(Color::WHITE),
+        transform: Transform::from_translation(Vec3::ZERO),
+        ..default()
+    },));
+
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(0.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+
+    commands.spawn(DirectionalLightBundle {
+        transform: Transform::from_xyz(3.0, 3.0, 3.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+}

--- a/earthmover-simulation/src/sim/backend/physics.rs
+++ b/earthmover-simulation/src/sim/backend/physics.rs
@@ -2,15 +2,18 @@
 
 use std::sync::Arc;
 
+use bevy::prelude::*;
+
 use bevy::{
     app::{App, Startup},
     asset::Assets,
-    color::Color,
     math::Vec3,
     pbr::{DirectionalLightBundle, PbrBundle, StandardMaterial},
     prelude::{Camera3dBundle, Commands, Cuboid, Mesh, ResMut, Resource, Transform},
     utils::default,
+    DefaultPlugins,
 };
+use bevy_rapier3d::prelude::Collider;
 use earthmover_achiever::goals::Rewardable;
 use std::collections::HashMap;
 use tokio::sync::mpsc::UnboundedSender;
@@ -48,7 +51,8 @@ impl Simulation for BevyPhysicsInformedBackend {
             .insert_resource(MessageChannel(message_sender))
             .insert_resource(ArcSimArgs(args))
             .insert_resource(TrainContext::<DIMS>::default())
-            .add_systems(Startup, setup)
+            .add_plugins(DefaultPlugins)
+            .add_systems(Startup, setup::<REWARD, DIMS>)
             .run();
     }
 }
@@ -56,20 +60,34 @@ impl Simulation for BevyPhysicsInformedBackend {
 /// Sets up the bevy simulation world with respect to the points provided
 #[allow(unused_attributes)]
 #[allow(elided_lifetimes_in_paths)]
-fn setup(
+fn setup<REWARD: Rewardable, const DIMS: usize>(
     mut commands: Commands,
+    args: Res<ArcSimArgs<REWARD, DIMS>>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn((PbrBundle {
-        mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::WHITE),
-        transform: Transform::from_translation(Vec3::ZERO),
-        ..default()
-    },));
+    for point in &args.0.data {
+        let point_in_3_space = Vec3::new(point[0], point[1], point[2]);
+
+        // If DIMS is higher than 3, the color of the point will correspond to the higher
+        // dimension peripheral readings
+        let last = point.len() - 1;
+        let r = point[last - 2];
+        let g = point[last - 1];
+        let b = point[last];
+
+        commands
+            .spawn(PbrBundle {
+                mesh: meshes.add(Mesh::from(Cuboid::new(0.01, 0.01, 0.01))),
+                material: materials.add(Color::srgb(r, g, b)),
+                transform: Transform::from_translation(point_in_3_space),
+                ..default()
+            })
+            .insert(Collider::cuboid(0.01, 0.01, 0.01));
+    }
 
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.0, -2.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });
 

--- a/wsl_example.sh
+++ b/wsl_example.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cargo build -p earthmover-simulation --example physics --target x86_64-pc-windows-gnu --release &&
+cp target/x86_64-pc-windows-gnu/debug/examples/physics.exe . &&
+exec ./physics.exe "$@"


### PR DESCRIPTION
This PR encapsulates the beginnings of the physics informed RL simulation our agent will be trained off of concurrently on the `Hivemind` server. We register all simulation arguments as a Bevy resource and pass them initially into the setup function. Currently, all this function does is render each point from the data buffer as a physics-collide-able cuboid object. The color of the point is currently determined by the readings of the last 3 points in this N-Dimensional point, meaning that in higher dimensions the peripheral readings will be visible and patterns can possibly be seen and look pretty cool. 

Fun other notes:

* Add `ValidDimension` trait that enforces the conditionality of our points is greater than 2 and less than 33, giving a compile-time error when this isn't the case.
* Create example program for visualizing one pass of a physics simulation. Right now it generates 10,000 points based off of random x and y coordinates and a z coordinate that corresponds to cos(2(x + y)) / 5. A picture of this example can be found below:

![image](https://github.com/user-attachments/assets/9e54c3fa-0339-4c22-a78e-029d82c66301)
Note: This image has 100,000 points instead of 10,000


