### PR TITLE
Initial Server Component Setup

### DIFF
--- a/earthmover-hivemind/Cargo.toml
+++ b/earthmover-hivemind/Cargo.toml
@@ -5,3 +5,9 @@ version.workspace = true
 authors.workspace = true
 
 [dependencies]
+futures-util = { version = "0.3.30", features = ["tokio-io"] }
+http-body-util = "0.1.2"
+hyper = { version = "1.4.1", features = ["full"] }
+hyper-tungstenite = "0.14.0"
+hyper-util = { version = "0.1.6", features = ["full", "tokio"] }
+tokio = { version = "1.39.2", features = ["full"] }

--- a/earthmover-hivemind/Cargo.toml
+++ b/earthmover-hivemind/Cargo.toml
@@ -13,3 +13,16 @@ hyper-util = { version = "0.1.6", features = ["full", "tokio"] }
 tokio = { version = "1.39.2", features = ["full"] }
 uuid = { version = "1.11.0", features = ["v4"] }
 earthmover-achiever = { path = "../earthmover-achiever" }
+
+[lints.rust]
+missing_docs = "warn"
+nonstandard-style = "warn"
+rust-2018-idioms = "warn"
+rust-2021-compatibility = "warn"
+rust-2024-compatibility = "warn"
+
+[lints.rustdoc]
+broken_intra_doc_links = "warn"
+
+[lints.clippy]
+missing_docs_in_private_items = "warn"

--- a/earthmover-hivemind/Cargo.toml
+++ b/earthmover-hivemind/Cargo.toml
@@ -11,3 +11,5 @@ hyper = { version = "1.4.1", features = ["full"] }
 hyper-tungstenite = "0.14.0"
 hyper-util = { version = "0.1.6", features = ["full", "tokio"] }
 tokio = { version = "1.39.2", features = ["full"] }
+uuid = { version = "1.11.0", features = ["v4"] }
+earthmover-achiever = { path = "../earthmover-achiever" }

--- a/earthmover-hivemind/src/lib.rs
+++ b/earthmover-hivemind/src/lib.rs
@@ -1,4 +1,22 @@
 //! All required defintions for handling AHTP incoming state messages
 
+use std::sync::Arc;
+
+use service::ServerService;
+use state::ServerState;
+use tokio::sync::RwLock;
+
 pub mod service;
 pub mod state;
+
+/// Creates a new State and State Service linked together by message and response channels
+pub fn new_state() -> (Arc<RwLock<ServerState>>, ServerService) {
+    let (msg_sender, msg_reader) = tokio::sync::mpsc::unbounded_channel();
+    let (res_sender, res_reader) = tokio::sync::mpsc::unbounded_channel();
+
+    let state = ServerState::new(msg_reader, res_sender);
+    let state_lock = Arc::new(RwLock::new(state));
+    let service = ServerService::new(state_lock.clone(), res_reader, msg_sender);
+
+    (state_lock, service)
+}

--- a/earthmover-hivemind/src/lib.rs
+++ b/earthmover-hivemind/src/lib.rs
@@ -1,0 +1,4 @@
+//! All required defintions for handling AHTP incoming state messages
+
+pub mod service;
+pub mod state;

--- a/earthmover-hivemind/src/main.rs
+++ b/earthmover-hivemind/src/main.rs
@@ -1,14 +1,14 @@
 //! The server crate responsible for handling incoming data and simulating physics of the
 //! environment
 
+use earthmover_hivemind::new_state;
 use hyper::server::conn::http1;
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpListener;
-use earthmover_hivemind::new_state;
 
 #[tokio::main]
 async fn main() {
-    let (state, service) = new_state();
+    let (_state, service) = new_state();
 
     let listener = TcpListener::bind("0.0.0.0:1940").await.unwrap();
     println!(
@@ -16,7 +16,6 @@ async fn main() {
         listener.local_addr().unwrap().port()
     );
 
-    let state_clone = state.clone();
     let connection_handler = async move {
         loop {
             // Handle connections
@@ -29,10 +28,7 @@ async fn main() {
 
             let service = service.clone();
             tokio::spawn(async move {
-                if let Err(e) = http1::Builder::new()
-                    .serve_connection(io, service)
-                    .await
-                {
+                if let Err(e) = http1::Builder::new().serve_connection(io, service).await {
                     eprintln!("Error serving connection: {}", e);
                 }
             });

--- a/earthmover-hivemind/src/main.rs
+++ b/earthmover-hivemind/src/main.rs
@@ -1,6 +1,46 @@
 //! The server crate responsible for handling incoming data and simulating physics of the
 //! environment
 
-fn main() {
-    println!("Hello, world!");
+use earthmover_hivemind::{service::ServerService, state::ServerState};
+use hyper::server::conn::http1;
+use hyper_util::rt::TokioIo;
+use std::sync::Arc;
+use tokio::{net::TcpListener, sync::RwLock};
+
+#[tokio::main]
+async fn main() {
+    let state = Arc::new(RwLock::new(ServerState::default()));
+
+    let listener = TcpListener::bind("0.0.0.0:1940").await.unwrap();
+    println!(
+        "Listening on http://localhost:{}",
+        listener.local_addr().unwrap().port()
+    );
+
+    let state_clone = state.clone();
+    let connection_handler = async move {
+        let state = state_clone.clone();
+        loop {
+            // Handle connections
+            let (socket, _) = listener
+                .accept()
+                .await
+                .expect("Error accepting incoming connection");
+
+            let io = TokioIo::new(socket);
+
+            let server_service = ServerService::new(state.clone());
+
+            tokio::spawn(async move {
+                if let Err(e) = http1::Builder::new()
+                    .serve_connection(io, server_service)
+                    .await
+                {
+                    eprintln!("Error serving connection: {}", e);
+                }
+            });
+        }
+    };
+
+    connection_handler.await
 }

--- a/earthmover-hivemind/src/service.rs
+++ b/earthmover-hivemind/src/service.rs
@@ -6,15 +6,21 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 
-use crate::state::ServerState;
+use crate::state::{message::{MessageSender, ResponseReceiver}, ServerState};
 
+#[derive(Clone)]
 pub struct ServerService {
     /// The current state this service works with respect to
     pub state: Arc<RwLock<ServerState>>,
+    /// The responses sent back
+    pub response_queue: Arc<RwLock<ResponseReceiver>>,
+    /// The message send channel
+    pub message_sender: MessageSender
 }
 
 impl ServerService {
-    pub fn new(state: Arc<RwLock<ServerState>>) -> Self {
-        Self { state }
+    /// Creates a new service instance
+    pub fn new(state: Arc<RwLock<ServerState>>, response_queue: ResponseReceiver, message_sender: MessageSender) -> Self {
+        Self { state, response_queue: Arc::new(RwLock::new(response_queue)), message_sender }
     }
 }

--- a/earthmover-hivemind/src/service.rs
+++ b/earthmover-hivemind/src/service.rs
@@ -6,8 +6,12 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 
-use crate::state::{message::{MessageSender, ResponseReceiver}, ServerState};
+use crate::state::{
+    message::{MessageSender, ResponseReceiver},
+    ServerState,
+};
 
+/// A server service handler
 #[derive(Clone)]
 pub struct ServerService {
     /// The current state this service works with respect to
@@ -15,12 +19,20 @@ pub struct ServerService {
     /// The responses sent back
     pub response_queue: Arc<RwLock<ResponseReceiver>>,
     /// The message send channel
-    pub message_sender: MessageSender
+    pub message_sender: MessageSender,
 }
 
 impl ServerService {
     /// Creates a new service instance
-    pub fn new(state: Arc<RwLock<ServerState>>, response_queue: ResponseReceiver, message_sender: MessageSender) -> Self {
-        Self { state, response_queue: Arc::new(RwLock::new(response_queue)), message_sender }
+    pub fn new(
+        state: Arc<RwLock<ServerState>>,
+        response_queue: ResponseReceiver,
+        message_sender: MessageSender,
+    ) -> Self {
+        Self {
+            state,
+            response_queue: Arc::new(RwLock::new(response_queue)),
+            message_sender,
+        }
     }
 }

--- a/earthmover-hivemind/src/service.rs
+++ b/earthmover-hivemind/src/service.rs
@@ -1,0 +1,20 @@
+//! The service for handling the current state
+
+pub mod service_impl;
+
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::state::ServerState;
+
+pub struct ServerService {
+    /// The current state this service works with respect to
+    pub state: Arc<RwLock<ServerState>>,
+}
+
+impl ServerService {
+    pub fn new(state: Arc<RwLock<ServerState>>) -> Self {
+        Self { state }
+    }
+}

--- a/earthmover-hivemind/src/service/service_impl.rs
+++ b/earthmover-hivemind/src/service/service_impl.rs
@@ -1,0 +1,51 @@
+//! The hyper service implementation for the custom `ServerService`
+
+use std::{future::Future, pin::Pin};
+
+use futures_util::StreamExt;
+use http_body_util::Full;
+use hyper::{
+    body::{self, Bytes},
+    service::Service,
+    Request, Response, StatusCode,
+};
+
+use super::ServerService;
+
+impl Service<Request<body::Incoming>> for ServerService {
+    type Response = Response<Full<Bytes>>;
+    type Error = hyper::http::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn call(&self, mut req: Request<body::Incoming>) -> Self::Future {
+        if hyper_tungstenite::is_upgrade_request(&req) {
+            let (response, websocket) =
+                hyper_tungstenite::upgrade(&mut req, None).expect("Error upgrading to WebSocket");
+            tokio::spawn(async move {
+                match websocket.await {
+                    Ok(ws) => {
+                        let (_writer, mut reader) = ws.split();
+                        while let Some(msg) = reader.next().await {
+                            match msg {
+                                Ok(_msg) => {
+                                    todo!("Handle incoming messages")
+                                }
+                                Err(err) => eprintln!("{err}"),
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        eprintln!("Failed to establish WebSocket Connection: {}", err)
+                    }
+                }
+            });
+
+            Box::pin(async { Ok(response) })
+        } else {
+            let response = Response::builder().status(StatusCode::OK);
+
+            let res = response.body(Full::new(Bytes::copy_from_slice(b"WIP :)")));
+            Box::pin(async { res })
+        }
+    }
+}

--- a/earthmover-hivemind/src/state.rs
+++ b/earthmover-hivemind/src/state.rs
@@ -1,5 +1,7 @@
 //! Current state of the server, including a message queue
 
+pub mod message;
+
 /// The current server's state
 #[derive(Default)]
 pub struct ServerState {}

--- a/earthmover-hivemind/src/state.rs
+++ b/earthmover-hivemind/src/state.rs
@@ -1,7 +1,20 @@
 //! Current state of the server, including a message queue
 
+use message::{MessageReceiver, ResponseSender};
+
 pub mod message;
 
 /// The current server's state
-#[derive(Default)]
-pub struct ServerState {}
+pub struct ServerState {
+    /// The messages waiitng to be handled
+    pub message_queue: MessageReceiver,
+    /// The pathway for sending out new responses
+    pub response_sender: ResponseSender,
+}
+
+impl ServerState {
+    /// Creates a new state
+    pub fn new(message_queue: MessageReceiver, response_sender: ResponseSender) -> Self {
+        Self { message_queue, response_sender }
+    }
+}

--- a/earthmover-hivemind/src/state.rs
+++ b/earthmover-hivemind/src/state.rs
@@ -1,0 +1,5 @@
+//! Current state of the server, including a message queue
+
+/// The current server's state
+#[derive(Default)]
+pub struct ServerState {}

--- a/earthmover-hivemind/src/state.rs
+++ b/earthmover-hivemind/src/state.rs
@@ -15,6 +15,9 @@ pub struct ServerState {
 impl ServerState {
     /// Creates a new state
     pub fn new(message_queue: MessageReceiver, response_sender: ResponseSender) -> Self {
-        Self { message_queue, response_sender }
+        Self {
+            message_queue,
+            response_sender,
+        }
     }
 }

--- a/earthmover-hivemind/src/state/message.rs
+++ b/earthmover-hivemind/src/state/message.rs
@@ -6,12 +6,12 @@ use uuid::Uuid;
 /// A message receiver for the message enum
 pub type MessageReceiver = tokio::sync::mpsc::UnboundedReceiver<Message>;
 /// A message sender for the message enum
-pub type MessageSender = tokio::sync::mpsc::UnboundedReceiver<Message>;
+pub type MessageSender = tokio::sync::mpsc::UnboundedSender<Message>;
 
 /// A response receiver for the response enum
 pub type ResponseReceiver = tokio::sync::mpsc::UnboundedReceiver<Response>;
 /// A response sender for the response enum
-pub type ResponseSender = tokio::sync::mpsc::UnboundedReceiver<Response>;
+pub type ResponseSender = tokio::sync::mpsc::UnboundedSender<Response>;
 
 /// All variants that a message can be, including connection requests and existing user contexts
 pub enum Message {

--- a/earthmover-hivemind/src/state/message.rs
+++ b/earthmover-hivemind/src/state/message.rs
@@ -1,0 +1,38 @@
+//! The variants a message may be
+
+use earthmover_achiever::brain::instruction::Instruction;
+use uuid::Uuid;
+
+/// A message receiver for the message enum
+pub type MessageReceiver = tokio::sync::mpsc::UnboundedReceiver<Message>;
+/// A message sender for the message enum
+pub type MessageSender = tokio::sync::mpsc::UnboundedReceiver<Message>;
+
+/// A response receiver for the response enum
+pub type ResponseReceiver = tokio::sync::mpsc::UnboundedReceiver<Response>;
+/// A response sender for the response enum
+pub type ResponseSender = tokio::sync::mpsc::UnboundedReceiver<Response>;
+
+/// All variants that a message can be, including connection requests and existing user contexts
+pub enum Message {
+    /// A client initial connection
+    Connection,
+    /// Set the dimensionality of this simulation
+    SetDims(Uuid, usize),
+    /// Send a data buffer in sequences of set dimension chunks(every n elements are considered a
+    /// point)
+    SendData(Uuid, Vec<f32>),
+    /// Set the goal for the current agent (what point in the dimension to focus on and whether we
+    /// want to maximize(true) or minizmize(false))
+    Goal(Uuid, Vec<(usize, bool)>),
+    /// Disconnect from the session
+    Disconnection,
+}
+
+/// All variants a server response may have
+pub enum Response {
+    /// Client is connected - here's the session ID
+    Connected(Uuid),
+    /// Generated instruction for achieving a goal
+    Instruction(Vec<Instruction>),
+}


### PR DESCRIPTION
This PR creates a basic HTTP webserver meant to be hosted on a cloud based training server (or local in offline cases). The server currently can take in HTTP and WebSocket connections, the AHTP protocol will be implemented in a following PR :)