### PR TITLE
Implement AHTP on Hivemind server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,15 @@ uuid = { version = "1.11.0", features = ["v4", "serde"] }
 bevy = "0.14.2"
 bevy_rapier3d = "0.27.0"
 futures = "0.3.30"
-earthmover-achiever = { path = "./earthmover-achiever" }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 rapier3d = "0.22.0"
 indicatif = "0.17.8"
 rand = "0.8.5"
 rppal = { version = "0.19.0" }
+
+earthmover-achiever = { path = "./earthmover-achiever" }
+earthmover-simulation = { path = "./earthmover-simulation" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ http-body-util = "0.1.2"
 hyper = { version = "1.4.1", features = ["full"] }
 hyper-tungstenite = "0.14.0"
 hyper-util = { version = "0.1.6", features = ["full", "tokio"] }
-uuid = { version = "1.11.0", features = ["v4"] }
+uuid = { version = "1.11.0", features = ["v4", "serde"] }
 bevy = "0.14.2"
 bevy_rapier3d = "0.27.0"
 futures = "0.3.30"

--- a/earthmover-achiever/src/brain/agent.rs
+++ b/earthmover-achiever/src/brain/agent.rs
@@ -4,7 +4,7 @@ use std::{error::Error, marker::PhantomData, time::Duration};
 
 use crate::{
     body::{Body, Peripheral},
-    goals::{Goal, Rewardable},
+    goals::Rewardable,
 };
 
 use super::{buffer::DataBuffer, instruction::Instruction};
@@ -24,7 +24,7 @@ pub type Result<T> = std::result::Result<T, Box<dyn Error>>;
 /// The response will then be a finished AgentSession that can be attempted to run in the field!
 pub struct AgentSession<'agent, REWARD: Rewardable, STATE, const BUFFER_SIZE: usize> {
     /// The goal of the agent
-    goal: Goal<REWARD>,
+    goal: REWARD,
     /// A reference to the agent's hardware
     body: &'agent mut Body,
     /// The data collection buffer
@@ -44,8 +44,8 @@ impl<'agent, REWARD: Rewardable, STATE, const BUFFER_SIZE: usize>
     }
 
     /// Gets the current reward of the agent session
-    pub fn get_reward(&self) -> Option<f64> {
-        self.goal.evaluate()
+    pub fn get_reward(&self) -> f64 {
+        self.goal.to_reward()
     }
 
     /// Returns a reference to the agent's hardware
@@ -88,7 +88,7 @@ impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize>
 /// directions bytes, preventing them from being runnable
 pub struct Builder<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize> {
     /// The goal
-    goal: Option<Goal<REWARD>>,
+    goal: Option<REWARD>,
     /// A reference to the agent's hardware
     body: Option<&'agent mut Body>,
 }
@@ -106,7 +106,7 @@ impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize> Default
 
 impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize> Builder<'agent, REWARD, BUFFER_SIZE> {
     /// Set an agent's goal
-    pub fn with_goal(mut self, goal: Goal<REWARD>) -> Self {
+    pub fn with_goal(mut self, goal: REWARD) -> Self {
         self.goal = Some(goal);
         self
     }

--- a/earthmover-achiever/src/goals.rs
+++ b/earthmover-achiever/src/goals.rs
@@ -1,5 +1,7 @@
 //! Defining what a goal can be
 
+pub mod multi_dim;
+
 /// Goals will be a modular abstraction over anything that we want the agent to do. It will be
 /// modular as this REWARD can be anything from a boolean to a dynamic reward type. It could be the
 /// reading from one or many peripherals. I think we should have some sort of exposed breadboard
@@ -10,33 +12,15 @@
 /// Reward would be an f32 to represent the reading from the flame sensor. During data collection
 /// the simulation would become aware of areas of higher flame concentration and infer to go close
 /// to these sources.
-pub enum Goal<REWARD: Rewardable> {
+pub enum Goal {
     /// Maximize this Reward's value
-    Maximize(REWARD),
+    Maximize,
     /// Minimize this Reward's value
-    Minimize(REWARD),
+    Minimize,
     /// A combination of goals
-    Complex(Vec<Goal<REWARD>>),
+    Complex(Vec<Goal>),
     /// No goal
     None,
-}
-
-impl<REWARD: Rewardable> Goal<REWARD> {
-    /// Evaluates a reward as its designated value
-    pub fn evaluate(&self) -> Option<f64> {
-        match self {
-            Self::Maximize(reward) | Self::Minimize(reward) => Some(reward.to_reward()),
-            Self::Complex(goals) => {
-                let mut res = 0.0;
-                for goal in goals {
-                    res += goal.evaluate()?;
-                }
-
-                Some(res)
-            }
-            Self::None => None,
-        }
-    }
 }
 
 /// Basic implementations of reward function for primitive types that make sense

--- a/earthmover-achiever/src/goals/multi_dim.rs
+++ b/earthmover-achiever/src/goals/multi_dim.rs
@@ -1,0 +1,14 @@
+//! A REWARD implementation for a struct wrt an agent's current position
+
+use super::{Goal, Rewardable};
+
+/// A REWARD trait impl for when context
+pub struct PositionContextualReward<const N: usize> {
+    _goals: [Option<Goal>; N],
+}
+
+impl<const N: usize> Rewardable for PositionContextualReward<N> {
+    fn to_reward(&self) -> f64 {
+        todo!()
+    }
+}

--- a/earthmover-achiever/src/main.rs
+++ b/earthmover-achiever/src/main.rs
@@ -4,12 +4,16 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use earthmover_achiever::brain::agent::Untrained;
-use earthmover_achiever::goals::Goal;
+use earthmover_achiever::goals::multi_dim::PositionContextualReward;
+use earthmover_achiever::goals::Rewardable;
 use earthmover_achiever::protocol::{AhtpMessage, AhtpResponse};
 use earthmover_achiever::{body::Body, brain::AgentSession};
 use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::protocol::Message;
+
+/// Dimensions
+pub const DIMS: usize = 3;
 
 #[derive(Parser, Debug)]
 /// Configuration for the achiever session from the CLI
@@ -30,7 +34,7 @@ struct Config {
 
 impl Config {
     /// Parses a config into an agent's Body and Goals
-    pub fn get_body_and_goals(&self) -> (Option<Body>, Option<Goal<f32>>) {
+    pub fn get_body_and_goals<REWARD: Rewardable>(&self) -> (Option<Body>, REWARD) {
         todo!()
     }
 }
@@ -42,9 +46,8 @@ pub async fn main() {
     let args = Config::parse();
 
     //Todo: Parse These Args into a Body and a Goal
-    let (body, goals) = args.get_body_and_goals();
+    let (body, goals): (_, PositionContextualReward<DIMS>) = args.get_body_and_goals();
     let mut body = body.unwrap();
-    let goals = goals.unwrap();
 
     let _threshold = args.threshold;
     let server_to = args.server.unwrap_or("0.0.0.0:1940".into());

--- a/earthmover-hivemind/Cargo.toml
+++ b/earthmover-hivemind/Cargo.toml
@@ -13,6 +13,7 @@ hyper-util = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
 earthmover-achiever = { workspace = true }
+earthmover-simulation = { workspace = true }
 
 [lints.rust]
 missing_docs = "warn"

--- a/earthmover-hivemind/Cargo.toml
+++ b/earthmover-hivemind/Cargo.toml
@@ -14,6 +14,8 @@ tokio = { workspace = true }
 uuid = { workspace = true }
 earthmover-achiever = { workspace = true }
 earthmover-simulation = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [lints.rust]
 missing_docs = "warn"

--- a/earthmover-hivemind/src/lib.rs
+++ b/earthmover-hivemind/src/lib.rs
@@ -1,22 +1,18 @@
 //! All required defintions for handling AHTP incoming state messages
 
-use std::sync::Arc;
-
+use earthmover_achiever::goals::Rewardable;
 use service::ServerService;
 use state::{message::MessageReceiver, ServerState};
-use tokio::sync::RwLock;
 
 pub mod service;
 pub mod state;
 
 /// Creates a new State and State Service linked together by message and response channels
-pub fn new_state() -> (MessageReceiver, Arc<RwLock<ServerState>>, ServerService) {
+pub fn new_state<REWARD: Rewardable + Default>() -> (MessageReceiver, ServerState<REWARD>, ServerService) {
     let (msg_sender, msg_reader) = tokio::sync::mpsc::unbounded_channel();
-    let (res_sender, res_reader) = tokio::sync::mpsc::unbounded_channel();
 
-    let state = ServerState::new(res_sender);
-    let state_lock = Arc::new(RwLock::new(state));
-    let service = ServerService::new(state_lock.clone(), res_reader, msg_sender);
+    let state = ServerState::default();
+    let service = ServerService::new(msg_sender);
 
-    (msg_reader, state_lock, service)
+    (msg_reader, state, service)
 }

--- a/earthmover-hivemind/src/lib.rs
+++ b/earthmover-hivemind/src/lib.rs
@@ -8,7 +8,8 @@ pub mod service;
 pub mod state;
 
 /// Creates a new State and State Service linked together by message and response channels
-pub fn new_state<REWARD: Rewardable + Default>() -> (MessageReceiver, ServerState<REWARD>, ServerService) {
+pub fn new_state<REWARD: Rewardable + Default>(
+) -> (MessageReceiver, ServerState<REWARD>, ServerService) {
     let (msg_sender, msg_reader) = tokio::sync::mpsc::unbounded_channel();
 
     let state = ServerState::default();

--- a/earthmover-hivemind/src/lib.rs
+++ b/earthmover-hivemind/src/lib.rs
@@ -3,20 +3,20 @@
 use std::sync::Arc;
 
 use service::ServerService;
-use state::ServerState;
+use state::{message::MessageReceiver, ServerState};
 use tokio::sync::RwLock;
 
 pub mod service;
 pub mod state;
 
 /// Creates a new State and State Service linked together by message and response channels
-pub fn new_state() -> (Arc<RwLock<ServerState>>, ServerService) {
+pub fn new_state() -> (MessageReceiver, Arc<RwLock<ServerState>>, ServerService) {
     let (msg_sender, msg_reader) = tokio::sync::mpsc::unbounded_channel();
     let (res_sender, res_reader) = tokio::sync::mpsc::unbounded_channel();
 
-    let state = ServerState::new(msg_reader, res_sender);
+    let state = ServerState::new(res_sender);
     let state_lock = Arc::new(RwLock::new(state));
     let service = ServerService::new(state_lock.clone(), res_reader, msg_sender);
 
-    (state_lock, service)
+    (msg_reader, state_lock, service)
 }

--- a/earthmover-hivemind/src/main.rs
+++ b/earthmover-hivemind/src/main.rs
@@ -8,7 +8,7 @@ use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() {
-    let (_state, service) = new_state();
+    let (mut msg_queue, _state, service) = new_state();
 
     let listener = TcpListener::bind("0.0.0.0:1940").await.unwrap();
     println!(
@@ -16,7 +16,7 @@ async fn main() {
         listener.local_addr().unwrap().port()
     );
 
-    let connection_handler = async move {
+    tokio::spawn(async move {
         loop {
             // Handle connections
             let (socket, _) = listener
@@ -33,7 +33,11 @@ async fn main() {
                 }
             });
         }
-    };
+    });
 
-    connection_handler.await
+    while let Some(msg) = msg_queue.recv().await {
+        match msg {
+            _ => todo!()
+        }
+    }
 }

--- a/earthmover-hivemind/src/main.rs
+++ b/earthmover-hivemind/src/main.rs
@@ -1,8 +1,10 @@
 //! The server crate responsible for handling incoming data and simulating physics of the
 //! environment
 
-
-use earthmover_hivemind::{new_state, state::message::{Message, Response}};
+use earthmover_hivemind::{
+    new_state,
+    state::message::{Message, Response},
+};
 use hyper::server::conn::http1;
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpListener;
@@ -40,19 +42,21 @@ async fn main() {
         match msg {
             Message::Connection(id, res_channel) => {
                 state.new_session(id, res_channel);
-            },
-            Message::SetDims(id, dims) => {
-
-            },
-            Message::Goal(id, goal) => {
+            }
+            Message::SetDims(id, dims) => state[&id].set_dims(dims),
+            Message::Goal(_id, _goal) => {
                 todo!();
-            },
+            }
             Message::SendData(id, buf) => state[&id].write(&buf),
             Message::Train(id) => {
                 if state[&id].train().is_none() {
-                    state[&id].send(Response::TrainError("Not all agent attributes have been set yet")).expect("Failed to send message to response channel");
+                    state[&id]
+                        .send(Response::TrainError(
+                            "Not all agent attributes have been set yet",
+                        ))
+                        .expect("Failed to send message to response channel");
                 }
-            },
+            }
             Message::Disconnection => {}
         }
     }

--- a/earthmover-hivemind/src/service.rs
+++ b/earthmover-hivemind/src/service.rs
@@ -13,11 +13,7 @@ pub struct ServerService {
 
 impl ServerService {
     /// Creates a new service instance
-    pub fn new(
-        message_sender: MessageSender,
-    ) -> Self {
-        Self {
-            message_sender,
-        }
+    pub fn new(message_sender: MessageSender) -> Self {
+        Self { message_sender }
     }
 }

--- a/earthmover-hivemind/src/service.rs
+++ b/earthmover-hivemind/src/service.rs
@@ -2,22 +2,11 @@
 
 pub mod service_impl;
 
-use std::sync::Arc;
-
-use tokio::sync::RwLock;
-
-use crate::state::{
-    message::{MessageSender, ResponseReceiver},
-    ServerState,
-};
+use crate::state::message::MessageSender;
 
 /// A server service handler
 #[derive(Clone)]
 pub struct ServerService {
-    /// The current state this service works with respect to
-    pub state: Arc<RwLock<ServerState>>,
-    /// The responses sent back
-    pub response_queue: Arc<RwLock<ResponseReceiver>>,
     /// The message send channel
     pub message_sender: MessageSender,
 }
@@ -25,13 +14,9 @@ pub struct ServerService {
 impl ServerService {
     /// Creates a new service instance
     pub fn new(
-        state: Arc<RwLock<ServerState>>,
-        response_queue: ResponseReceiver,
         message_sender: MessageSender,
     ) -> Self {
         Self {
-            state,
-            response_queue: Arc::new(RwLock::new(response_queue)),
             message_sender,
         }
     }

--- a/earthmover-hivemind/src/service/service_impl.rs
+++ b/earthmover-hivemind/src/service/service_impl.rs
@@ -2,13 +2,16 @@
 
 use std::{future::Future, pin::Pin};
 
-use futures_util::StreamExt;
+use futures_util::{SinkExt, StreamExt};
 use http_body_util::Full;
 use hyper::{
     body::{self, Bytes},
     service::Service,
     Request, Response, StatusCode,
 };
+use uuid::Uuid;
+
+use crate::state::message::Message;
 
 use super::ServerService;
 
@@ -18,17 +21,45 @@ impl Service<Request<body::Incoming>> for ServerService {
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn call(&self, mut req: Request<body::Incoming>) -> Self::Future {
+        let sender = self.message_sender.clone();
         if hyper_tungstenite::is_upgrade_request(&req) {
             let (response, websocket) =
                 hyper_tungstenite::upgrade(&mut req, None).expect("Error upgrading to WebSocket");
             tokio::spawn(async move {
                 match websocket.await {
                     Ok(ws) => {
-                        let (_writer, mut reader) = ws.split();
+                        let (mut writer, mut reader) = ws.split();
+                        let id = Uuid::new_v4();
+                        let (com_writer, mut com_reader) = tokio::sync::mpsc::unbounded_channel();
+                        sender
+                            .send(Message::Connection(id, com_writer))
+                            .expect("Failed to send to sender");
+
+                        tokio::spawn(async move {
+                            while let Some(response) = com_reader.recv().await {
+                                writer
+                                    .send(hyper_tungstenite::tungstenite::Message::Text(
+                                        response
+                                            .serialize_to_string()
+                                            .expect("Failed to serialize response message"),
+                                    ))
+                                    .await
+                                    .expect("Failed to send ws message");
+                            }
+                        });
+
                         while let Some(msg) = reader.next().await {
                             match msg {
-                                Ok(_msg) => {
-                                    todo!("Handle incoming messages")
+                                Ok(msg) => {
+                                    if let hyper_tungstenite::tungstenite::Message::Text(txt) = msg
+                                    {
+                                        let message = Message::from_string(&txt);
+                                        if let Ok(message) = message {
+                                            sender
+                                                .send(message)
+                                                .expect("Failed to send back to channel");
+                                        }
+                                    }
                                 }
                                 Err(err) => eprintln!("{err}"),
                             }
@@ -44,7 +75,21 @@ impl Service<Request<body::Incoming>> for ServerService {
         } else {
             let response = Response::builder().status(StatusCode::OK);
 
-            let res = response.body(Full::new(Bytes::copy_from_slice(b"WIP :)")));
+            let message = r#"
+    EARTHMOVER HIVEMIND
+
+                .-~~~-.
+              /        }
+             /      .-~
+            |        }
+___\.~~-.-~|     .-~_
+    { O  |  ` .-~.   ; ~-.__
+     ~--~/-|_\|  :   : .-~
+        /  |  \~ - - ~
+       /   |   \       
+    "#;
+
+            let res = response.body(Full::new(Bytes::copy_from_slice(message.as_bytes())));
             Box::pin(async { res })
         }
     }

--- a/earthmover-hivemind/src/state.rs
+++ b/earthmover-hivemind/src/state.rs
@@ -5,10 +5,7 @@ use std::{
     ops::{Index, IndexMut},
 };
 
-use earthmover_achiever::{
-    body::Body,
-    goals::{Goal, Rewardable},
-};
+use earthmover_achiever::{body::Body, goals::Rewardable};
 use earthmover_simulation::{sim::backend::physics::BevyPhysicsInformedBackend, Orchestrator};
 use message::{Response, ResponseSender};
 use uuid::Uuid;
@@ -54,7 +51,7 @@ pub struct Connection<REWARD: Rewardable> {
     /// Simulation dimensions
     dims: usize,
     /// Current goal
-    goal: Option<Goal<REWARD>>,
+    goal: Option<REWARD>,
     /// Current body
     body: Option<Body>,
     /// Current data read in

--- a/earthmover-hivemind/src/state.rs
+++ b/earthmover-hivemind/src/state.rs
@@ -1,8 +1,14 @@
 //! Current state of the server, including a message queue
 
-use std::{collections::HashMap, ops::{Index, IndexMut}};
+use std::{
+    collections::HashMap,
+    ops::{Index, IndexMut},
+};
 
-use earthmover_achiever::{body::Body, goals::{Goal, Rewardable}};
+use earthmover_achiever::{
+    body::Body,
+    goals::{Goal, Rewardable},
+};
 use earthmover_simulation::{sim::backend::physics::BevyPhysicsInformedBackend, Orchestrator};
 use message::{Response, ResponseSender};
 use uuid::Uuid;
@@ -17,10 +23,11 @@ pub const NUM_DIMS: usize = 3;
 /// The current server's state
 #[derive(Default)]
 pub struct ServerState<REWARD: Rewardable> {
+    /// The sessions this state is aware of
     sessions: HashMap<Uuid, Connection<REWARD>>,
 }
 
-impl<'agent, REWARD: Rewardable> ServerState<REWARD> {
+impl<REWARD: Rewardable> ServerState<REWARD> {
     /// Adds a new session to the internal sessions
     pub fn new_session(&mut self, id: Uuid, channel: ResponseSender) {
         self.sessions.insert(id, Connection::new(channel));
@@ -40,20 +47,30 @@ impl<REWARD: Rewardable> IndexMut<&Uuid> for ServerState<REWARD> {
     }
 }
 
-
 /// A current connection session
 pub struct Connection<REWARD: Rewardable> {
+    /// Where to send response messages
     response_channel: ResponseSender,
+    /// Simulation dimensions
     dims: usize,
+    /// Current goal
     goal: Option<Goal<REWARD>>,
+    /// Current body
     body: Option<Body>,
+    /// Current data read in
     buf: Vec<f32>,
 }
 
 impl<REWARD: Rewardable> Connection<REWARD> {
     /// Creates a new connection with just a response channel
     pub fn new(response_channel: ResponseSender) -> Self {
-        Self { response_channel, dims: 0, goal: None, body: None, buf: vec![] }
+        Self {
+            response_channel,
+            dims: 0,
+            goal: None,
+            body: None,
+            buf: vec![],
+        }
     }
 
     /// Sets the dims for this session
@@ -62,7 +79,10 @@ impl<REWARD: Rewardable> Connection<REWARD> {
     }
 
     /// Sends a response to the underlying client
-    pub fn send(&mut self, response: Response) -> Result<(), tokio::sync::mpsc::error::SendError<message::Response>> {
+    pub fn send(
+        &mut self,
+        response: Response,
+    ) -> Result<(), tokio::sync::mpsc::error::SendError<message::Response>> {
         self.response_channel.send(response)
     }
 
@@ -77,7 +97,8 @@ impl<REWARD: Rewardable> Connection<REWARD> {
             return None;
         }
 
-        let _orchestrator: Orchestrator<BevyPhysicsInformedBackend, NUM_DIMS> = Orchestrator::new(BevyPhysicsInformedBackend);
+        let _orchestrator: Orchestrator<BevyPhysicsInformedBackend, NUM_DIMS> =
+            Orchestrator::new(BevyPhysicsInformedBackend);
 
         Some(())
     }

--- a/earthmover-hivemind/src/state.rs
+++ b/earthmover-hivemind/src/state.rs
@@ -1,20 +1,84 @@
 //! Current state of the server, including a message queue
 
-use message::ResponseSender;
+use std::{collections::HashMap, ops::{Index, IndexMut}};
+
+use earthmover_achiever::{body::Body, goals::{Goal, Rewardable}};
+use earthmover_simulation::{sim::backend::physics::BevyPhysicsInformedBackend, Orchestrator};
+use message::{Response, ResponseSender};
+use uuid::Uuid;
 
 pub mod message;
 
+/// How many simulations per "batch"
+pub const NUM_SIMS: usize = 100_000;
+/// Dimension of batch
+pub const NUM_DIMS: usize = 3;
+
 /// The current server's state
-pub struct ServerState {
-    /// The pathway for sending out new responses
-    pub response_sender: ResponseSender,
+#[derive(Default)]
+pub struct ServerState<REWARD: Rewardable> {
+    sessions: HashMap<Uuid, Connection<REWARD>>,
 }
 
-impl ServerState {
-    /// Creates a new state
-    pub fn new(response_sender: ResponseSender) -> Self {
-        Self {
-            response_sender,
+impl<'agent, REWARD: Rewardable> ServerState<REWARD> {
+    /// Adds a new session to the internal sessions
+    pub fn new_session(&mut self, id: Uuid, channel: ResponseSender) {
+        self.sessions.insert(id, Connection::new(channel));
+    }
+}
+
+impl<REWARD: Rewardable> Index<&Uuid> for ServerState<REWARD> {
+    type Output = Connection<REWARD>;
+    fn index(&self, index: &Uuid) -> &Self::Output {
+        &self.sessions[index]
+    }
+}
+
+impl<REWARD: Rewardable> IndexMut<&Uuid> for ServerState<REWARD> {
+    fn index_mut(&mut self, index: &Uuid) -> &mut Self::Output {
+        self.sessions.get_mut(index).unwrap()
+    }
+}
+
+
+/// A current connection session
+pub struct Connection<REWARD: Rewardable> {
+    response_channel: ResponseSender,
+    dims: usize,
+    goal: Option<Goal<REWARD>>,
+    body: Option<Body>,
+    buf: Vec<f32>,
+}
+
+impl<REWARD: Rewardable> Connection<REWARD> {
+    /// Creates a new connection with just a response channel
+    pub fn new(response_channel: ResponseSender) -> Self {
+        Self { response_channel, dims: 0, goal: None, body: None, buf: vec![] }
+    }
+
+    /// Sets the dims for this session
+    pub fn set_dims(&mut self, dims: usize) {
+        self.dims = dims
+    }
+
+    /// Sends a response to the underlying client
+    pub fn send(&mut self, response: Response) -> Result<(), tokio::sync::mpsc::error::SendError<message::Response>> {
+        self.response_channel.send(response)
+    }
+
+    /// Writes data to the buffer
+    pub fn write(&mut self, buf: &[f32]) {
+        self.buf.extend(buf)
+    }
+
+    /// Begins training the agent
+    pub fn train(&mut self) -> Option<()> {
+        if self.goal.is_none() || self.body.is_none() {
+            return None;
         }
+
+        let _orchestrator: Orchestrator<BevyPhysicsInformedBackend, NUM_DIMS> = Orchestrator::new(BevyPhysicsInformedBackend);
+
+        Some(())
     }
 }

--- a/earthmover-hivemind/src/state.rs
+++ b/earthmover-hivemind/src/state.rs
@@ -1,22 +1,19 @@
 //! Current state of the server, including a message queue
 
-use message::{MessageReceiver, ResponseSender};
+use message::ResponseSender;
 
 pub mod message;
 
 /// The current server's state
 pub struct ServerState {
-    /// The messages waiitng to be handled
-    pub message_queue: MessageReceiver,
     /// The pathway for sending out new responses
     pub response_sender: ResponseSender,
 }
 
 impl ServerState {
     /// Creates a new state
-    pub fn new(message_queue: MessageReceiver, response_sender: ResponseSender) -> Self {
+    pub fn new(response_sender: ResponseSender) -> Self {
         Self {
-            message_queue,
             response_sender,
         }
     }

--- a/earthmover-hivemind/src/state/message.rs
+++ b/earthmover-hivemind/src/state/message.rs
@@ -16,7 +16,7 @@ pub type ResponseSender = tokio::sync::mpsc::UnboundedSender<Response>;
 /// All variants that a message can be, including connection requests and existing user contexts
 pub enum Message {
     /// A client initial connection
-    Connection,
+    Connection(Uuid, ResponseSender),
     /// Set the dimensionality of this simulation
     SetDims(Uuid, usize),
     /// Send a data buffer in sequences of set dimension chunks(every n elements are considered a
@@ -25,6 +25,8 @@ pub enum Message {
     /// Set the goal for the current agent (what point in the dimension to focus on and whether we
     /// want to maximize(true) or minizmize(false))
     Goal(Uuid, Vec<(usize, bool)>),
+    /// Begin training
+    Train(Uuid),
     /// Disconnect from the session
     Disconnection,
 }
@@ -35,4 +37,6 @@ pub enum Response {
     Connected(Uuid),
     /// Generated instruction for achieving a goal
     Instruction(Vec<Instruction>),
+    /// Training error
+    TrainError(&'static str),
 }

--- a/earthmover-hivemind/src/state/message.rs
+++ b/earthmover-hivemind/src/state/message.rs
@@ -1,6 +1,7 @@
 //! The variants a message may be
 
 use earthmover_achiever::brain::instruction::Instruction;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// A message receiver for the message enum
@@ -14,8 +15,10 @@ pub type ResponseReceiver = tokio::sync::mpsc::UnboundedReceiver<Response>;
 pub type ResponseSender = tokio::sync::mpsc::UnboundedSender<Response>;
 
 /// All variants that a message can be, including connection requests and existing user contexts
+#[derive(Deserialize, Serialize)]
 pub enum Message {
     /// A client initial connection
+    #[serde(skip_deserializing, skip_serializing)]
     Connection(Uuid, ResponseSender),
     /// Set the dimensionality of this simulation
     SetDims(Uuid, usize),
@@ -31,7 +34,20 @@ pub enum Message {
     Disconnection,
 }
 
+impl Message {
+    /// Attempts to get a message from a serde string
+    pub fn from_string(from: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(from)
+    }
+
+    /// Attempts to serialize a message to a json string
+    pub fn to_string(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
 /// All variants a server response may have
+#[derive(Serialize)]
 pub enum Response {
     /// Client is connected - here's the session ID
     Connected(Uuid),
@@ -39,4 +55,11 @@ pub enum Response {
     Instruction(Vec<Instruction>),
     /// Training error
     TrainError(&'static str),
+}
+
+impl Response {
+    /// Attempts to serialize the given response to a json string
+    pub fn serialize_to_string(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
 }

--- a/earthmover-simulation/src/sim/backend/physics.rs
+++ b/earthmover-simulation/src/sim/backend/physics.rs
@@ -35,6 +35,7 @@ pub struct TrainContext<const DIMS: usize> {
 }
 
 /// A Physics Informed Backend Runner
+#[derive(Clone, Copy)]
 pub struct BevyPhysicsInformedBackend;
 
 impl Simulation for BevyPhysicsInformedBackend {


### PR DESCRIPTION
Define enums and message pipelines for allowing all types of AHTP message to come through the server. The server owns a set of 'sessions' accessible by a `Uuid`, allowing websocket communication from the agent to the server

From here, what's left is finalizing the agent's communication with this server, and the callback with new instructions.