### PR TITLE
Initial Setup for Physics Informed Learning

### DIFF
--- a/earthmover-achiever/src/brain/agent.rs
+++ b/earthmover-achiever/src/brain/agent.rs
@@ -54,8 +54,8 @@ impl<'agent, REWARD: Rewardable, STATE, const BUFFER_SIZE: usize>
     }
 }
 
-impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize>
-    AgentSession<'agent, REWARD, Untrained, BUFFER_SIZE>
+impl<REWARD: Rewardable, const BUFFER_SIZE: usize>
+    AgentSession<'_, REWARD, Untrained, BUFFER_SIZE>
 {
     /// Adds a slice of data to the buffer, if that slice is too large `None` is returned
     pub fn add_data(&mut self, buf: &[f32]) -> Option<()> {
@@ -63,9 +63,7 @@ impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize>
     }
 }
 
-impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize>
-    AgentSession<'agent, REWARD, InReview, BUFFER_SIZE>
-{
+impl<REWARD: Rewardable, const BUFFER_SIZE: usize> AgentSession<'_, REWARD, InReview, BUFFER_SIZE> {
     /// Gets the directions of a newly trained Agent
     pub fn act(&mut self) -> Result<()> {
         if let Some(instructions) = &self.directions {
@@ -93,9 +91,7 @@ pub struct Builder<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize> {
     body: Option<&'agent mut Body>,
 }
 
-impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize> Default
-    for Builder<'agent, REWARD, BUFFER_SIZE>
-{
+impl<REWARD: Rewardable, const BUFFER_SIZE: usize> Default for Builder<'_, REWARD, BUFFER_SIZE> {
     fn default() -> Self {
         Self {
             goal: None,

--- a/earthmover-simulation/src/sim/backend/physics.rs
+++ b/earthmover-simulation/src/sim/backend/physics.rs
@@ -56,7 +56,7 @@ impl Simulation for BevyPhysicsInformedBackend {
             .add_plugins(DefaultPlugins)
             .add_plugins(RapierPhysicsPlugin::<NoUserData>::default())
             .add_systems(Startup, setup::<REWARD, DIMS>)
-            //.add_systems(Update, update::<REWARD, DIMS>)
+            .add_systems(Update, update::<REWARD, DIMS>)
             .run();
     }
 }
@@ -107,23 +107,22 @@ fn setup<REWARD: Rewardable, const DIMS: usize>(
         .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(Sphere::new(0.1))),
             material: materials.add(Color::WHITE),
-            transform: Transform::from_xyz(0.0, 0.0, 5.0), // Initial position
+            transform: Transform::from_xyz(0.0, 5.0, 0.0),
             ..default()
         })
-    .insert(RigidBody::Dynamic)
-        .insert(Collider::ball(0.01))
+        .insert(RigidBody::Dynamic)
+        .insert(Collider::ball(0.1))
         .insert(GravityScale(1.0))
         .insert(Restitution::coefficient(0.7))
-        .insert(Velocity::linear(Vec3::new(0.0, -0.01, 0.0)));
+        .insert(Velocity::linear(Vec3::ZERO));
 
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, -5.0, 0.5).looking_at(Vec3::ZERO, Vec3::Z),
+        transform: Transform::from_xyz(0.0, 5.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });
 
-
     commands.spawn(DirectionalLightBundle {
-        transform: Transform::from_xyz(3.0, 3.0, 3.0).looking_at(Vec3::ZERO, Vec3::Z),
+        transform: Transform::from_xyz(3.0, 3.0, 3.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });
 }

--- a/earthmover-simulation/src/sim/backend/physics.rs
+++ b/earthmover-simulation/src/sim/backend/physics.rs
@@ -92,7 +92,7 @@ fn setup<REWARD: Rewardable, const DIMS: usize>(
                 PbrBundle {
                     mesh: mesh_handle.clone(),
                     material: material_handle,
-                    transform: Transform::from_translation(Vec3::new(point[0], point[1], point[2])),
+                    transform: Transform::from_xyz(point[0], point[1], point[2]),
                     ..default()
                 },
                 Collider::cuboid(0.01, 0.01, 0.01),

--- a/earthmover-simulation/src/sim/backend/physics.rs
+++ b/earthmover-simulation/src/sim/backend/physics.rs
@@ -13,7 +13,8 @@ use bevy::{
     utils::default,
     DefaultPlugins,
 };
-use bevy_rapier3d::prelude::Collider;
+use bevy_rapier3d::plugin::{NoUserData, RapierPhysicsPlugin};
+use bevy_rapier3d::prelude::{Collider, GravityScale, Restitution, RigidBody, Velocity};
 use earthmover_achiever::goals::Rewardable;
 use std::collections::HashMap;
 use tokio::sync::mpsc::UnboundedSender;
@@ -53,7 +54,9 @@ impl Simulation for BevyPhysicsInformedBackend {
             .insert_resource(ArcSimArgs(args))
             .insert_resource(TrainContext::<DIMS>::default())
             .add_plugins(DefaultPlugins)
+            .add_plugins(RapierPhysicsPlugin::<NoUserData>::default())
             .add_systems(Startup, setup::<REWARD, DIMS>)
+            //.add_systems(Update, update::<REWARD, DIMS>)
             .run();
     }
 }
@@ -93,19 +96,39 @@ fn setup<REWARD: Rewardable, const DIMS: usize>(
                     ..default()
                 },
                 Collider::cuboid(0.01, 0.01, 0.01),
+                RigidBody::Fixed,
             )
         })
         .collect();
 
     commands.spawn_batch(points);
 
+    commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(Mesh::from(Sphere::new(0.1))),
+            material: materials.add(Color::WHITE),
+            transform: Transform::from_xyz(0.0, 0.0, 5.0), // Initial position
+            ..default()
+        })
+    .insert(RigidBody::Dynamic)
+        .insert(Collider::ball(0.01))
+        .insert(GravityScale(1.0))
+        .insert(Restitution::coefficient(0.7))
+        .insert(Velocity::linear(Vec3::new(0.0, -0.01, 0.0)));
+
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, -2.0, 1.0).looking_at(Vec3::ZERO, Vec3::Z),
+        transform: Transform::from_xyz(0.0, -5.0, 0.5).looking_at(Vec3::ZERO, Vec3::Z),
         ..default()
     });
+
 
     commands.spawn(DirectionalLightBundle {
         transform: Transform::from_xyz(3.0, 3.0, 3.0).looking_at(Vec3::ZERO, Vec3::Z),
         ..default()
     });
 }
+
+#[allow(unused_attributes)]
+#[allow(elided_lifetimes_in_paths)]
+/// Sets up the Bevy simulation world with respect to the points provided
+fn update<REWARD: Rewardable, const DIMS: usize>() {}


### PR DESCRIPTION
This PR introduces Rapier3d as our physics engine for simulations run. This physics backend implements the swappable `Backend` trait and loads all appropriate data points. Currently as a test it spawns a ball that responds to gravity and treats the points as solid collision objects.

* The next step, once URDF parsing is underway, is to load the body into the simulation, generate a batch of instructions and act them out accordingly. 

* The backend has access to a message channel for the score and instructions that can be read by the orchestrator. Not much new is added here, but it is necessary so that our axis aren't swapped like they were. 