### PR TITLE
Ignore Jupyter Notebooks from langauge stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-generated


### PR DESCRIPTION
We don't want 98% of the repo to show as notebooks