### PR TITLE
Implement Achiever Server Connection and Communication

### DIFF
--- a/earthmover-achiever/Cargo.toml
+++ b/earthmover-achiever/Cargo.toml
@@ -17,6 +17,7 @@ tokio-tungstenite = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true }
 rppal = { workspace = true, optional = true }
+deku = "0.18.1"
 
 [features]
 default = []

--- a/earthmover-achiever/src/brain/agent.rs
+++ b/earthmover-achiever/src/brain/agent.rs
@@ -65,6 +65,13 @@ impl<REWARD: Rewardable, const BUFFER_SIZE: usize>
     pub fn add_data(&mut self, buf: &[f32]) -> Option<()> {
         self.buffer.add_data(buf)
     }
+
+    pub fn export(&mut self) -> Vec<f32> {
+        let res = self.buffer.export();
+        self.buffer = DataBuffer::default();
+
+        res
+    }
 }
 
 impl<REWARD: Rewardable, const BUFFER_SIZE: usize> AgentSession<'_, REWARD, InReview, BUFFER_SIZE> {

--- a/earthmover-achiever/src/brain/agent.rs
+++ b/earthmover-achiever/src/brain/agent.rs
@@ -35,14 +35,18 @@ pub struct AgentSession<'agent, REWARD: Rewardable, STATE, const BUFFER_SIZE: us
     _spooky_ghost: PhantomData<STATE>,
 }
 
-impl<'agent, REWARD: Rewardable, STATE, const BUFFER_SIZE: usize>
-    AgentSession<'agent, REWARD, STATE, BUFFER_SIZE>
+impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize>
+    AgentSession<'agent, REWARD, Untrained, BUFFER_SIZE>
 {
     /// Creates a new builder for an agent's session
     pub fn builder() -> Builder<'agent, REWARD, BUFFER_SIZE> {
         Builder::default()
     }
+}
 
+impl<'agent, REWARD: Rewardable, STATE, const BUFFER_SIZE: usize>
+    AgentSession<'agent, REWARD, STATE, BUFFER_SIZE>
+{
     /// Gets the current reward of the agent session
     pub fn get_reward(&self) -> f64 {
         self.goal.to_reward()

--- a/earthmover-achiever/src/brain/agent.rs
+++ b/earthmover-achiever/src/brain/agent.rs
@@ -44,8 +44,8 @@ impl<'agent, REWARD: Rewardable, const BUFFER_SIZE: usize>
     }
 }
 
-impl<'agent, REWARD: Rewardable, STATE, const BUFFER_SIZE: usize>
-    AgentSession<'agent, REWARD, STATE, BUFFER_SIZE>
+impl<REWARD: Rewardable, STATE, const BUFFER_SIZE: usize>
+    AgentSession<'_, REWARD, STATE, BUFFER_SIZE>
 {
     /// Gets the current reward of the agent session
     pub fn get_reward(&self) -> f64 {

--- a/earthmover-achiever/src/brain/buffer.rs
+++ b/earthmover-achiever/src/brain/buffer.rs
@@ -45,6 +45,10 @@ impl<const BUFFER_SIZE: usize> DataBuffer<BUFFER_SIZE> {
         }
     }
 
+    pub fn export(&self) -> Vec<f32> {
+        self.data[0..(*self.marker)].to_vec()
+    }
+
     /// Returns a mutable reference to the current byte, then increments the marker
     fn get(&mut self) -> Option<&mut f32> {
         let mut_byte = &mut self.data[*self.marker];

--- a/earthmover-achiever/src/communication.rs
+++ b/earthmover-achiever/src/communication.rs
@@ -1,0 +1,100 @@
+//! Implementation of communication protocol on the board itself with the Mega peripheral reader
+
+/// A communication packet for Board to Board peripheral communication
+#[derive(Clone, Copy, Debug)]
+pub struct MoverPacket {
+    pub version: u8,
+    pub msg_type: MessageType,
+    pub len: u16,
+}
+
+impl MoverPacket {
+    pub fn new(version: u8, msg_type: MessageType, len: u16) -> Self {
+        Self {
+            version,
+            msg_type,
+            len,
+        }
+    }
+
+    pub fn v1_from_data(msg_type: MessageType, data: &[u8]) -> Self {
+        Self {
+            version: 1,
+            msg_type,
+            len: data.len() as u16,
+        }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 4] {
+        let len_split = self.len.to_be_bytes();
+        [
+            self.version,
+            self.msg_type as u8,
+            len_split[0],
+            len_split[1],
+        ]
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != 4 {
+            None
+        } else {
+            let version = bytes[0];
+            let msg_type_byte = bytes[1];
+            let msg_type = MessageType::from_byte(msg_type_byte)?;
+            let split = [bytes[2], bytes[3]];
+            let len = u16::from_be_bytes(split);
+
+            Some(Self::new(version, msg_type, len))
+        }
+    }
+
+    pub fn serialize_completely(&self, data: &[u8]) -> Vec<u8> {
+        let mut res = vec![];
+        let bytes = self.to_bytes();
+        res.extend(bytes.iter());
+        res.extend(data.iter());
+
+        res
+    }
+}
+
+/// Message header type, essentially what type of data to expect from the packet's payload
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub enum MessageType {
+    Lidar,
+    Accelerometer,
+    //... implement more as needed
+}
+
+impl MessageType {
+    pub fn from_byte(byte: u8) -> Option<Self> {
+        match byte {
+            0 => Some(Self::Lidar),
+            1 => Some(Self::Accelerometer),
+            _ => None,
+        }
+    }
+}
+
+/// Reads an entire stream of bytes as tuples between MoverPackets and their payloads
+pub fn data_stream_to_packet_pairs(input: &[u8]) -> Option<Vec<(MoverPacket, &[u8])>> {
+    let mut res = vec![];
+    let mut reader = input;
+
+    while reader.len() >= 4 {
+        let packet = MoverPacket::from_bytes(&reader[0..4])?;
+        let len = packet.len;
+        let data = &reader[0..(4 + len as usize)];
+        res.push((packet, data));
+        reader = &reader[(4 + len as usize)..];
+    }
+
+    Some(res)
+}
+
+/// Blocks and reads an entire message packet and data pair from an external source
+pub fn read_packet() -> (MoverPacket, Vec<u8>) {
+    todo!("Chrissy and I need to work on this part together, this is where we'll interface with the Mega");
+}

--- a/earthmover-achiever/src/goals.rs
+++ b/earthmover-achiever/src/goals.rs
@@ -17,10 +17,16 @@ pub enum Goal {
     Maximize,
     /// Minimize this Reward's value
     Minimize,
-    /// A combination of goals
-    Complex(Vec<Goal>),
-    /// No goal
-    None,
+}
+
+impl Goal {
+    /// Matches the goal and returns a score based on distance away from the point
+    pub fn match_against(&self, val: f64, ceiling: f64) -> f64 {
+        match *self {
+            Self::Maximize => -((ceiling - val).abs()),
+            Self::Minimize => (ceiling - val).abs()
+        }
+    }
 }
 
 /// Basic implementations of reward function for primitive types that make sense

--- a/earthmover-achiever/src/goals.rs
+++ b/earthmover-achiever/src/goals.rs
@@ -12,6 +12,7 @@ pub mod multi_dim;
 /// Reward would be an f32 to represent the reading from the flame sensor. During data collection
 /// the simulation would become aware of areas of higher flame concentration and infer to go close
 /// to these sources.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Goal {
     /// Maximize this Reward's value
     Maximize,

--- a/earthmover-achiever/src/goals.rs
+++ b/earthmover-achiever/src/goals.rs
@@ -25,7 +25,7 @@ impl Goal {
     pub fn match_against(&self, val: f64, ceiling: f64) -> f64 {
         match *self {
             Self::Maximize => -((ceiling - val).abs()),
-            Self::Minimize => (ceiling - val).abs()
+            Self::Minimize => (ceiling - val).abs(),
         }
     }
 }

--- a/earthmover-achiever/src/goals/multi_dim.rs
+++ b/earthmover-achiever/src/goals/multi_dim.rs
@@ -4,11 +4,19 @@ use super::{Goal, Rewardable};
 
 /// A REWARD trait impl for when context
 pub struct PositionContextualReward<const N: usize> {
-    _goals: [Option<Goal>; N],
+    goals: [Option<Goal>; N],
+    curr_reading: [f64; N],
 }
 
 impl<const N: usize> Rewardable for PositionContextualReward<N> {
     fn to_reward(&self) -> f64 {
-        todo!()
+        let mut final_score = 0.0;
+        for (goal, val) in self.goals.iter().zip(self.curr_reading.iter()) {
+            if let Some(goal) = goal {
+                final_score += goal.match_against(*val, 1.0);
+            }
+        }
+
+        final_score
     }
 }

--- a/earthmover-achiever/src/goals/multi_dim.rs
+++ b/earthmover-achiever/src/goals/multi_dim.rs
@@ -3,9 +3,16 @@
 use super::{Goal, Rewardable};
 
 /// A REWARD trait impl for when context
+#[derive(Clone, Copy)]
 pub struct PositionContextualReward<const N: usize> {
     goals: [Option<Goal>; N],
     curr_reading: [f64; N],
+}
+
+impl<const N: usize> PositionContextualReward<N> {
+    pub fn set_reading(&mut self, new_pos: [f64; N]) {
+        self.curr_reading = new_pos
+    }
 }
 
 impl<const N: usize> Rewardable for PositionContextualReward<N> {

--- a/earthmover-achiever/src/goals/multi_dim.rs
+++ b/earthmover-achiever/src/goals/multi_dim.rs
@@ -9,9 +9,32 @@ pub struct PositionContextualReward<const N: usize> {
     curr_reading: [f64; N],
 }
 
+impl<const N: usize> Default for PositionContextualReward<N> {
+    fn default() -> Self {
+        Self {
+            goals: [None; N],
+            curr_reading: [0.0; N],
+        }
+    }
+}
+
 impl<const N: usize> PositionContextualReward<N> {
+    /// Sets the current reading of the agent
     pub fn set_reading(&mut self, new_pos: [f64; N]) {
         self.curr_reading = new_pos
+    }
+
+    /// Updates a set of goals based on id-goal pairings
+    pub fn update(&mut self, goals: Vec<(usize, bool)>) {
+        for (idx, maximize) in goals {
+            if N < idx {
+                let goal = match maximize {
+                    true => Goal::Maximize,
+                    false => Goal::Minimize,
+                };
+                self.goals[idx] = Some(goal)
+            }
+        }
     }
 }
 

--- a/earthmover-achiever/src/lib.rs
+++ b/earthmover-achiever/src/lib.rs
@@ -6,5 +6,6 @@ compile_error! {"Jetson Nano and Raspberry Pi cannot both be targetted by the sa
 
 pub mod body;
 pub mod brain;
+pub mod communication;
 pub mod goals;
 pub mod protocol;

--- a/earthmover-hivemind/Cargo.toml
+++ b/earthmover-hivemind/Cargo.toml
@@ -16,6 +16,7 @@ earthmover-achiever = { workspace = true }
 earthmover-simulation = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [lints.rust]
 missing_docs = "warn"

--- a/earthmover-hivemind/src/lib.rs
+++ b/earthmover-hivemind/src/lib.rs
@@ -1,6 +1,5 @@
 //! All required defintions for handling AHTP incoming state messages
 
-use earthmover_achiever::goals::Rewardable;
 use service::ServerService;
 use state::{message::MessageReceiver, ServerState};
 
@@ -8,8 +7,7 @@ pub mod service;
 pub mod state;
 
 /// Creates a new State and State Service linked together by message and response channels
-pub fn new_state<REWARD: Rewardable + Default>(
-) -> (MessageReceiver, ServerState<REWARD>, ServerService) {
+pub fn new_state() -> (MessageReceiver, ServerState, ServerService) {
     let (msg_sender, msg_reader) = tokio::sync::mpsc::unbounded_channel();
 
     let state = ServerState::default();

--- a/earthmover-hivemind/src/main.rs
+++ b/earthmover-hivemind/src/main.rs
@@ -53,7 +53,7 @@ async fn main() {
             }
             Message::SendData(id, buf) => state[&id].write(&buf),
             Message::Train(id) => {
-                if state[&id].train().is_none() {
+                if state[&id].train().await.is_none() {
                     state[&id]
                         .send(Response::TrainError(
                             "Not all agent attributes have been set yet",

--- a/earthmover-simulation/src/sim.rs
+++ b/earthmover-simulation/src/sim.rs
@@ -39,9 +39,9 @@ pub struct ArcSimArgs<REWARD: Rewardable + Send + Sync + 'static, const DIMS: us
 #[derive(Default, Debug)]
 pub struct SimRes {
     /// The agent's score
-    score: f64,
+    pub score: f64,
     /// The instructions to achieve this score
-    instructions: Vec<Instruction>,
+    pub instructions: Vec<Instruction>,
 }
 
 impl PartialOrd for SimRes {


### PR DESCRIPTION
This PR finishes the basic workflow of sending data from the dog up to a hivemind server, it finishes the CLI app that will run on startup setting parameters like server listener and dimensionality, and defines the communication protocol from Jetson to Mega that Chrissy and I have been discussing. The general flow goes as follows:

`[ Agent is Initialized ] -> [ Agent collects point-based data until it's internal buffer is filled ] -> [ Upon buffer fill, data is flushed over websocket to the hivemind server ]`

The next steps to finish agent actions are to properly implement the `TODO` block for communicating with the Mega and finalize the response from the Hivemind server to act out the agent's actions. 